### PR TITLE
fix: Downgrade ADK to 1.16.0 for Task 3.0 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,15 @@
 # Core Dependencies for Transplant Medication Adherence Multi-Agent System
 
 # INSTALLATION:
-# pip install google-adk==1.17.0
+# pip install google-adk==1.16.0
 # pip install -r requirements.txt
 #
 # Note: Let pip resolve all ADK dependencies automatically.
 # The --no-deps workaround is NOT needed - pip will handle conflicts.
 
 # Google Agent Development Kit (ADK)
-google-adk==1.17.0
+# Pinned to 1.16.0 - version 1.17.0 introduced breaking API changes to agent.run()
+google-adk==1.16.0
 
 # Google Cloud Services
 google-cloud-firestore==2.13.0


### PR DESCRIPTION
## Problem
Task 3.0 integration tests blocked due to ADK API incompatibility. ADK 1.17.0 introduced breaking changes that affected all 3 parallel implementations.

## Root Cause
- ADK 1.17.0 changed Agent API significantly
- Task 2.0 agents use  which never existed in any ADK version
- Task 3.0 implementations use correct  pattern
- All 3 worktrees need compatible ADK version to run tests

## Solution
Downgrade to **ADK 1.16.0** (last stable version before 1.17.0).

## Changes
- `requirements.txt`: Changed `google-adk==1.17.0` → `google-adk==1.16.0`
- Added comment explaining why pinned to 1.16.0

## Impact
✅ **Unblocks all 3 Task 3.0 implementations:**
- In-process implementation can run integration tests
- Pub/Sub implementation can run integration tests
- ADK Orchestration implementation can run integration tests

✅ **Fast fix for hackathon timeline:**
- Simple dependency change
- No code modifications needed
- Task 3.0 implementations already use correct API

✅ **Task 2.0 agents unchanged:**
- Remain as reference implementation
- Not used in production architecture
- Task 3.0 implementations are the testable/deployable code

## Testing
- Verified ADK 1.16.0 installs successfully
- Confirmed Task 3.0 worktree agents use compatible API
- Pre-commit hooks passed

## Next Steps After Merge
1. Merge to main
2. Pull updated main into all 3 Task 3.0 worktrees
3. Run integration tests on each implementation
4. Run benchmarks to compare performance
5. Choose winning architecture based on data

## Related Work
- Closes abandoned PR #12 (incorrect run_async() approach)
- Unblocks Task 3.0 integration testing
- Related to PRs #9, #10, #11 (3 parallel implementations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>