### PR TITLE
docs: sync ai-dev-tasks canonical files from project_template

### DIFF
--- a/docs/ai-docs/create-adr.md
+++ b/docs/ai-docs/create-adr.md
@@ -1,0 +1,98 @@
+# Rule: Creating an Architecture Decision Record (ADR)
+
+## Goal
+
+To capture significant architectural or design decisions in a lightweight, append-only format that survives longer than chat history and is more focused than a full PRD. ADRs document *why* a choice was made — the context, alternatives, and trade-offs. The *what* lives in the code itself.
+
+ADRs are the long-term memory of a codebase. A future developer (possibly you, six months from now) reading the code will wonder "why is it this way?" — ADRs are the answer.
+
+## When to Create an ADR
+
+Create an ADR when:
+
+- A PRD has multiple valid implementation approaches and one is chosen over the others
+- A significant technology, library, or pattern decision is being made (e.g., Postgres over SQLite, REST over GraphQL, monorepo over polyrepo)
+- A previous decision is being reversed or superseded
+- A deliberate trade-off is being locked in that a future reader would need context to understand
+- During task execution, you realize a non-obvious design choice is being made that isn't explained by the surrounding code
+
+**Do NOT create an ADR for:**
+
+- Trivial implementation details (variable naming, formatting, single-function refactors)
+- Choices that are self-evident from the code
+- Ephemeral or experimental decisions (use commit messages instead)
+- Decisions already well-documented in an existing ADR — update the existing one's status if superseding
+
+## Process
+
+1. **Check for existing ADRs:** Scan `docs/adr/` for the highest existing ADR number and for any ADRs related to this decision. If a related ADR exists and the new decision supersedes it, note that relationship.
+2. **Determine the next ADR number:** Use the next integer, zero-padded to 4 digits (e.g., `0008`). ADRs are append-only and numbered sequentially.
+3. **Draft the ADR** using the structure below.
+4. **Save:** `docs/adr/NNNN-short-kebab-title.md`. Create the `docs/adr/` directory if it doesn't exist.
+5. **Cross-reference:**
+   - If the ADR came out of a PRD, add a link to the PRD under the ADR's **Related** section.
+   - Update the PRD's **Related Work** section to reference the new ADR.
+   - If this ADR supersedes an older one, update the older ADR's **Status** line to `Superseded by ADR-NNNN` and link the new one.
+6. **Commit on the current feature branch:** ADRs ride along with the PR that introduces the decision — they do not get their own PR.
+
+## ADR Structure
+
+````markdown
+# ADR NNNN: [Short Decision Title]
+
+## Status
+
+[Proposed | Accepted | Deprecated | Superseded by ADR-XXXX]
+
+## Context
+
+What is the issue we're facing? What forces are at play (technical, political, organizational, project)? Describe the situation factually — no solutions yet. A future reader who has no context should be able to understand *why this decision needed to be made* from this section alone.
+
+## Decision
+
+What did we decide to do? State it plainly in the active voice: "We will X."
+
+Keep this section short. The detail goes in Consequences and Alternatives.
+
+## Consequences
+
+What becomes easier as a result of this decision? What becomes harder? What new obligations does it create? What assumptions is it resting on that might not hold later?
+
+Include both positive and negative consequences honestly. A section that only lists upsides is a suspect ADR.
+
+## Alternatives Considered
+
+- **[Alternative A]** — brief description and why not chosen
+- **[Alternative B]** — brief description and why not chosen
+- **Do nothing** — what happens if we don't make any change (always worth stating)
+
+## Related
+
+- PRD: `docs/features/[feature-name]-PLANNED/prd.md` (if this ADR stems from a PRD)
+- Related ADRs: ADR-XXXX, ADR-YYYY
+- Issue: #NN
+- PR: #MM (filled in after the PR is opened)
+````
+
+## Status Lifecycle
+
+- **Proposed** — drafted but not yet accepted (rare; most ADRs skip straight to Accepted when committed)
+- **Accepted** — the decision is in effect
+- **Deprecated** — the decision no longer applies, but nothing has replaced it
+- **Superseded by ADR-XXXX** — explicitly replaced by a later ADR; link the replacement
+
+**ADRs are append-only.** Never edit an old ADR's Decision or Context after it has been accepted. If the decision changes, write a new ADR that supersedes the old one and update the old one's Status line only. The historical record is the point.
+
+## Target Audience
+
+The reader is a future developer — possibly you — trying to understand why the codebase is the way it is. They have the current code but no context. They are not in the room. Write for them.
+
+Avoid jargon that won't make sense out of context. Avoid "we decided to use X" without explaining why X was better than Y. Avoid omitting the alternatives — "we chose X" without "we rejected Y" is half an ADR.
+
+## Final Instructions
+
+1. Do NOT create an ADR for trivial decisions — prefer code comments or commit messages
+2. Check `docs/adr/` for existing ADRs before writing a new one
+3. Use the structure above verbatim
+4. Cross-reference from the PRD (if applicable) and update any superseded ADRs' status lines
+5. Commit on the current feature branch alongside the PRD and implementation — ADRs do not get their own PR

--- a/docs/ai-docs/create-prd.md
+++ b/docs/ai-docs/create-prd.md
@@ -7,10 +7,18 @@ To guide an AI assistant in creating a detailed Product Requirements Document (P
 ## Process
 
 1. **Receive Initial Prompt:** The user provides a brief description or request for a new feature or functionality. It could be a few lines, or a github issue.
-2. ** Get a perspective on the project by reading details from Readme.md, Claude.md, docs/, the last 5 PRs in github, and any logged github issues
-3. ** Ask Clarifying Questions:** Before writing the PRD, the AI *must* ask clarifying questions to gather sufficient detail. The goal is to understand the "what" and "why" of the feature, not necessarily the "how" (which the developer will figure out).
-4. ** Generate PRD:** Based on the initial prompt and the user's answers to the clarifying questions, generate a PRD using the structure outlined below.
-5. ** Save PRD:** Create a new feature directory `docs/features/[feature-name]-PLANNED/` and save the generated document as `prd.md` inside that directory.
+2. **Get a perspective on the project** by reading details from README.md, CLAUDE.md, docs/, the last 5 PRs in github, and any logged github issues.
+3. **Check for Related Work:** Scan `docs/features/` for existing PRDs and `docs/adr/` for existing ADRs that might overlap, duplicate, or extend the new request. If any are found, list them and confirm with the user whether this is a new feature, an extension, or a supersession before proceeding.
+4. **Ask Clarifying Questions:** Before writing the PRD, the AI *must* ask clarifying questions to gather sufficient detail. The goal is to understand the "what" and "why" of the feature, not necessarily the "how" (which the developer will figure out).
+5. **Generate PRD:** Based on the initial prompt and the user's answers to the clarifying questions, generate a PRD using the structure outlined below.
+6. **Save PRD:** Create a new feature directory `docs/features/[feature-name]-PLANNED/` and save the generated document as `prd.md` inside that directory.
+7. **Commit PRD on a feature branch:** If not already on a feature branch, create one: `git checkout -b feature/[feature-name]`. Never commit the PRD to `main`. Stage, commit, and push with `-u` to establish remote tracking.
+8. **Create a single tracking issue:** Use `gh issue create` to open **one** tracking issue for the feature. Do NOT create multiple issues per PRD — a single tracking issue keeps traceability simple and matches the one-logical-change-per-PR workflow.
+   - **Title:** the PRD title
+   - **Body:** a one-paragraph summary, the repo-relative path to the PRD (`docs/features/[feature-name]-PLANNED/prd.md`), and the feature branch name
+   - **Labels:** `feature` (or the repo's existing feature-tracking label)
+9. **Link the issue back into the PRD:** Update the PRD's **Related Work** section with the issue URL and commit the update. Two commits on the feature branch is fine — the first establishes the PRD, the second closes the cross-reference loop.
+10. **Flag architectural decisions for ADRs:** If the PRD process surfaced a significant architectural or design decision (choosing approach A over B, adopting a new dependency, picking a data store, etc.), ask the user whether to also create an ADR using `create-adr.md`. ADRs ride along in the same feature branch as the PRD.
 
 ## Status Management
 - **PLANNED**: Feature is documented but not yet started
@@ -49,6 +57,7 @@ The generated PRD should include the following sections:
 7.  **Technical Considerations (Optional):** Mention any known technical constraints, dependencies, or suggestions (e.g., "Should integrate with the existing Auth module").
 8.  **Success Metrics:** How will the success of this feature be measured? (e.g., "Increase user engagement by 10%", "Reduce support tickets related to X").
 9.  **Open Questions:** List any remaining questions or areas needing further clarification.
+10. **Related Work:** Links to the tracking GitHub issue, related PRDs in `docs/features/`, and related ADRs in `docs/adr/`. Start as a placeholder during drafting; fill in after the tracking issue is created.
 
 ### Option 2: Comprehensive Engineering PRD Structure
 
@@ -69,6 +78,7 @@ For complex technical features or when requested by the user, use this more deta
 10. **Risks and Mitigation:** Risk/mitigation strategy pairs
 11. **Out of Scope:** Clear exclusions and boundaries
 12. **Acceptance Criteria:** Grouped validation criteria
+13. **Related Work:** Links to the tracking GitHub issue, related PRDs in `docs/features/`, and related ADRs in `docs/adr/`. Start as a placeholder during drafting; fill in after the tracking issue is created.
 
 ### When to Use Each Structure
 
@@ -85,8 +95,85 @@ Assume the primary reader of the PRD is a **junior developer**. Therefore, requi
 *   **Location:** `docs/features/[feature-name]-PLANNED/`
 *   **Filename:** `[feature-name]-prd.md`
 
+## Clarification Questions Output Format
+
+After gathering context and before asking clarifying questions, output all questions to the terminal in this structured format:
+
+```
+=== PRD CLARIFICATION QUESTIONS ===
+
+Question 1: [Question text]
+     1.1: [Option 1]
+     1.2: [Option 2]
+     1.3: [Option 3]
+     ...
+     1.N: [Option N]
+     1.X: Something else
+
+Question 2: [Question text]
+     2.1: [Option 1]
+     2.2: [Option 2]
+     2.3: [Option 3]
+     ...
+     2.N: [Option N]
+     2.X: Something else
+
+...
+
+Question N: [Question text]
+     N.1: [Option 1]
+     N.2: [Option 2]
+     N.3: [Option 3]
+     ...
+     N.N: [Option N]
+     N.X: Something else
+
+===================================
+```
+
+**Guidelines:**
+- Each question should have 2-5 specific options plus the "X: Something else" option
+- Options should be actionable and specific to the feature context
+- The "X: Something else" option always allows for custom input
+- Number questions sequentially (1, 2, 3, ...)
+- Number options within each question (1.1, 1.2, etc.)
+- Use this format before engaging in the conversational Q&A with the user
+
+**Example:**
+
+```
+=== PRD CLARIFICATION QUESTIONS ===
+
+Question 1: What is the primary goal of this user authentication feature?
+     1.1: Allow new users to create accounts
+     1.2: Enable existing users to log in securely
+     1.3: Support social login (Google, GitHub, etc.)
+     1.4: Implement password reset functionality
+     1.X: Something else
+
+Question 2: Which authentication method should be prioritized?
+     2.1: Email and password
+     2.2: OAuth (social login)
+     2.3: Magic link (passwordless)
+     2.4: Multi-factor authentication (MFA)
+     2.X: Something else
+
+Question 3: What platforms need to support this feature?
+     3.1: Web only (desktop)
+     3.2: Web (desktop + mobile responsive)
+     3.3: Native mobile apps (iOS/Android)
+     3.4: All platforms
+     3.X: Something else
+
+===================================
+```
+
 ## Final instructions
 1. Do NOT start implementing the PRD
-2. Make sure to ask the user clarifying questions
-3. Take the user's answers to the clarifying questions and improve the PRD
-4. Ask the user if they want to break the prd down into dev tasks using generate-tasks.mdc (Reply "yes" or "y" to continue)
+2. Output clarifying questions using the structured format above
+3. Make sure to ask the user clarifying questions
+4. Take the user's answers to the clarifying questions and improve the PRD
+5. Commit the PRD on a feature branch (never `main`) and push with `-u`
+6. Create a single GitHub tracking issue with `gh issue create` and link it in the PRD's Related Work section
+7. If the PRD involved a significant architectural decision, prompt the user to create an ADR using `create-adr.md`
+8. Ask the user if they want to break the PRD down into dev tasks using `generate-tasks.md` (Reply "yes" or "y" to continue)

--- a/docs/ai-docs/generate-tasks.md
+++ b/docs/ai-docs/generate-tasks.md
@@ -68,8 +68,12 @@ The generated task list _must_ follow this structure:
 ## Interaction Model
 The process explicitly requires a pause after generating parent tasks to get user confirmation ("Go") before proceeding to generate the detailed sub-tasks.
 This ensures the high-level plan aligns with user expectations before diving into details.
-Offer to process the task list using process-task-list.mdc
+Offer to process the task list using `process-task-list.md`
 (Reply "yes" or "y" to continue)
+
+## Flagging Architectural Decisions
+
+While generating tasks, watch for sub-tasks that imply a significant architectural or design choice that is not obvious from the PRD (e.g., "choose between Redis and in-memory caching", "decide on ORM", "pick a diffing strategy"). If a task implies such a decision, note it inline in the task list with `(ADR needed)` and remind the user at the end of generation that an ADR should be created using `create-adr.md` before or during that sub-task's execution.
 
 ## Target Audience
 Assume the primary reader of the task list is a **junior developer** who will implement the feature.

--- a/docs/ai-docs/process-task-list.md
+++ b/docs/ai-docs/process-task-list.md
@@ -31,6 +31,10 @@ When working with task lists, the AI must:
 3. Add newly discovered tasks.
 4. Keep “Relevant Files” accurate and up to date.
 5. Before starting work, check which sub‑task is next.
-6. After implementing a sub‑task, update the file,
-7. Pause for user approval to commit to gh. (Reply "yes" or "y" to continue)
-8. Commit code code to git.
+6. After implementing a sub‑task, update the file.
+7. Pause for user approval to commit to gh. (Reply “yes” or “y” to continue)
+8. Commit code to git.
+
+## Architectural Decisions During Execution
+
+If while executing a sub-task you realize a significant architectural or design decision is being made that isn't explained by the PRD or existing code (e.g., choosing a library, locking in a data model, picking between two valid approaches), **pause and create an ADR using `create-adr.md` before committing the implementation**. The ADR rides along in the same feature branch as the code change. This prevents undocumented decisions from accreting silently as you work through the task list.


### PR DESCRIPTION
## Summary
Syncs AI dev workflow rule files from canonical source `project_template/docs/ai-docs/`. Part of a coordinated sync across ~14 repos.

## Changes
- **New file:** `docs/ai-docs/create-adr.md` — Architecture Decision Record workflow (Michael Nygard format, append-only, saved to `docs/adr/`)
- **`create-prd.md`:** Related Work check, commit-on-branch, single tracking issue, ADR trigger, Related Work sections in PRD structures
- **`generate-tasks.md`:** `(ADR needed)` markers for non-obvious design choices
- **`process-task-list.md`:** pause-and-write-ADR when locking in a design choice mid-execution

Canonical source: adamkwhite/project_template#55

## Test plan
- [x] Docs-only sync, no code changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)