### PR TITLE
docs: automate PLANNED → IN_PROGRESS rename in process-task-list

### DIFF
--- a/docs/ai-docs/create-prd.md
+++ b/docs/ai-docs/create-prd.md
@@ -21,11 +21,20 @@ To guide an AI assistant in creating a detailed Product Requirements Document (P
 10. **Flag architectural decisions for ADRs:** If the PRD process surfaced a significant architectural or design decision (choosing approach A over B, adopting a new dependency, picking a data store, etc.), ask the user whether to also create an ADR using `create-adr.md`. ADRs ride along in the same feature branch as the PRD.
 
 ## Status Management
-- **PLANNED**: Feature is documented but not yet started
-- **IN_PROGRESS**: Feature is being actively developed
-- **COMPLETED**: Feature is fully implemented and deployed
 
-Rename the directory to reflect current status (e.g., `user-auth-PLANNED` → `user-auth-IN_PROGRESS` → `user-auth-COMPLETED`).
+The feature folder suffix tracks lifecycle state:
+
+- **PLANNED**: Feature is documented but implementation has not begun
+- **IN_PROGRESS**: Feature is being actively developed
+- **COMPLETED**: Feature is fully implemented and merged
+
+**State transitions are automated — the user never renames these folders manually:**
+
+1. `create-prd.md` creates the folder at `-PLANNED`.
+2. `process-task-list.md` promotes it to `-IN_PROGRESS` as the first step of task execution, when real work begins (code changes, not just planning).
+3. The `close-the-loop` GitHub Action (`.github/workflows/close-the-loop.yml`) promotes it to `-COMPLETED` automatically when the feature's PR merges into `main` and the PR touched files outside `docs/features/`.
+
+If you find a folder in a state that doesn't match the workflow phase (e.g., still `-PLANNED` after implementation has started), rename it by hand with `git mv` and commit — but the expected path is for the three automated steps above to handle everything.
 
 ## Clarifying Questions (Examples)
 

--- a/docs/ai-docs/process-task-list.md
+++ b/docs/ai-docs/process-task-list.md
@@ -2,6 +2,23 @@
 
 Guidelines for managing task lists in markdown files to track progress on completing a PRD
 
+## Starting Execution
+
+Before implementing any sub-task, promote the feature folder from `-PLANNED` to `-IN_PROGRESS`. This is the point in the workflow where planning ends and work begins — the folder name must reflect that.
+
+1. **Locate the parent feature folder.** It is the directory containing `tasks.md` (e.g., `docs/features/user-auth-PLANNED/`).
+2. **If the folder is named `*-PLANNED`:**
+   - `git mv docs/features/[feature-name]-PLANNED docs/features/[feature-name]-IN_PROGRESS`
+   - If `status.md` exists inside, update it:
+     - Replace `Implementation Status: PLANNED` with `Implementation Status: IN_PROGRESS`
+     - Replace `📋 PLANNED` with `🚧 IN_PROGRESS` in the title line
+     - Update `**Last Updated:**` to today's date
+   - Commit on the current feature branch with subject `chore: start work on [feature-name]`.
+3. **If the folder is already `*-IN_PROGRESS`:** proceed directly — the rename was done on a prior run.
+4. **If the folder is `*-COMPLETED`:** stop and confirm with the user. You should not be executing a task list against a completed feature.
+
+This transition happens exactly once per feature, at the start of implementation. The `-IN_PROGRESS` → `-COMPLETED` transition is handled automatically by the `close-the-loop` GitHub Action when the feature's PR merges into `main` — do not attempt it manually here.
+
 ## Task Implementation
 - Start a new gh branch
 - **One sub-task at a time:** Do **NOT** start the next sub‑task until you ask the user for permission and they say “yes” or "y"


### PR DESCRIPTION
## Summary
Syncs updated `create-prd.md` and `process-task-list.md` from `project_template/docs/ai-docs/`. Closes the last gap in the automated state machine — Claude now handles PLANNED → IN_PROGRESS automatically at the start of task execution.

## The complete lifecycle

| Transition | Owner | When |
|---|---|---|
| *(nothing)* → `-PLANNED` | `create-prd.md` | At PRD creation |
| `-PLANNED` → `-IN_PROGRESS` | `process-task-list.md` | Step 1 of task execution |
| `-IN_PROGRESS` → `-COMPLETED` | `close-the-loop.yml` | On PR merge with code changes |

The user never renames these folders by hand.

## Changes
- **`process-task-list.md`:** new `## Starting Execution` section requiring the `-PLANNED` → `-IN_PROGRESS` rename + `status.md` update before any sub-task execution. Idempotent.
- **`create-prd.md`:** `Status Management` section rewritten to explicitly list the three automated transitions and their owners.

Canonical source: adamkwhite/project_template#57

## Test plan
- [x] Docs-only sync, no code changes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)