### PR TITLE
fix(security): bump google-adk and Flask in services/missed-dose

### DIFF
--- a/services/missed-dose/requirements.txt
+++ b/services/missed-dose/requirements.txt
@@ -1,11 +1,11 @@
 # Google ADK for multi-agent system (install first)
-google-adk==1.17.0
+google-adk==1.31.1
 
 # Google Cloud Services
 google-cloud-firestore==2.13.0
 google-generativeai==0.3.0
 
 # Web Framework
-Flask==3.0.0
+Flask>=3.1.3
 flask-cors>=4.0.2
 gunicorn>=23.0.0


### PR DESCRIPTION
## Summary
- `google-adk` 1.17.0 → 1.31.1
- `Flask` 3.0.0 → >=3.1.3

## Why
Closes two open Dependabot alerts on `services/missed-dose/requirements.txt`:
- **GHSA-rg7c-g689-fr3x (CVE-2026-4810)** — *critical*: code injection + missing authentication in `google-adk < 1.28.1`. Pinning to 1.31.1 to match the root `requirements.txt` (currently inconsistent).
- **GHSA-68rp-wp8r-4726 (CVE-2026-27205)** — *low*: Flask sessions can bypass `Vary: Cookie` header on certain key-only access patterns; fixed in 3.1.3. Bumping was also required to satisfy the pre-commit safety hook.

## Notes
- `google-cloud-firestore==2.13.0` and `google-generativeai==0.3.0` in this file are also far behind root, but are not security-flagged. Out of scope here — happy to do a follow-up alignment PR if you want.

## Test plan
- [ ] CI passes (pre-commit safety scan should now go green)
- [ ] services/missed-dose still builds and tests pass on the bumped ADK + Flask
- [ ] Both Dependabot alerts close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)