### PR TITLE
chore(ci): skip CI workflows on .github/** changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
-    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore']
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   pull_request:
     branches: [main]
-    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore']
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   workflow_dispatch:  # Allow manual triggers
 
 concurrency:


### PR DESCRIPTION
## Summary

Adds `.github/**` to `paths-ignore` in `ci.yml` so workflow-only PRs skip heavy CI gates cleanly. Mirrors [project_template PR #69](https://github.com/adamkwhite/project_template/pull/69).

## Changes

- `ci.yml`: appended `'.github/**'` to the existing `paths-ignore` lists for both `push` and `pull_request` triggers.

## Skipped (no changes needed)

- `close-the-loop.yml`: only triggers on `pull_request: types: [closed]`.

## Anomalies (surfaced for follow-up, not modified here)

- `security.yml` and `sonarcloud.yml` have `pull_request:`/`push:` triggers but **no `paths-ignore` list at all**. Per the rule, this PR does not add one from scratch.

## Test plan

- [ ] CI runs on this PR (it touches `.github/**` AND a non-workflow file? No — only a workflow. After merge, future workflow-only PRs to `ci.yml` should skip CI.)
- [ ] Confirm green checks before merge.