### PR TITLE
chore(ci): add paths-ignore to workflows that lacked one

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,6 +3,7 @@ name: Security Scanning
 on:
   pull_request:
     branches: [main]
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   schedule:
     # Run weekly on Mondays at 9am UTC
     - cron: '0 9 * * 1'

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -3,9 +3,11 @@ name: SonarCloud Analysis
 on:
   push:
     branches: [main]
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
+    paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']
   workflow_dispatch:  # Allow manual triggers
 
 concurrency:


### PR DESCRIPTION
## Summary
- Add `paths-ignore: ['*.md', 'docs/**', 'LICENSE', '.gitignore', '.github/**']` to the `pull_request` trigger in `.github/workflows/security.yml`.
- Add the same `paths-ignore` to the `push` and `pull_request` triggers in `.github/workflows/sonarcloud.yml`.
- `schedule` and `workflow_dispatch` triggers are intentionally left untouched.

Brings both workflows up to spec with the project_template idiom so PRs touching only docs, LICENSE, gitignore, or `.github/**` files skip the heavy security and SonarCloud gates instead of running them against zero changed source.

## Test plan
- [ ] CI runs (or skips appropriately) on this PR
- [ ] Security workflow no longer triggers on doc-only PRs going forward
- [ ] SonarCloud workflow no longer triggers on doc-only PRs going forward

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>