### PR TITLE
feat: restore stashed slash commands + missed-dose imports + test_adk_api

### DIFF
--- a/.claude/commands/clean.md
+++ b/.claude/commands/clean.md
@@ -1,0 +1,190 @@
+---
+description: Clean up Claude Code cache, logs, and temporary files to free disk space
+---
+
+## Your Task
+
+**Analyze** accumulated Claude Code cache and logs, then **ask the user** before cleaning anything.
+
+**IMPORTANT:**
+- Steps 1-4: Analysis only (read-only, safe)
+- Step 5: Cleaning (requires user confirmation)
+- Step 6: Deep cleaning (requires explicit user confirmation)
+
+**Do NOT run Step 5 or Step 6 without asking the user first!**
+
+## Context
+
+Claude Code accumulates data over time:
+- Debug logs (can reach 3GB+)
+- Old proxy databases (1GB+ per version)
+- Proxy session files (171+ log files, 30MB)
+- Project caches (2GB+)
+- File history (50MB+)
+
+This command helps identify and clean these files safely.
+
+## Commands to Execute
+
+### Step 1: Show Current Disk Usage
+
+First, check current ~/.claude directory size:
+
+```bash
+du -sh ~/.claude 2>/dev/null || echo "~/.claude directory not found"
+```
+
+### Step 2: Analyze What's Taking Space
+
+Show breakdown of ~/.claude contents:
+
+```bash
+du -sh ~/.claude/* 2>/dev/null | sort -hr
+```
+
+### Step 3: Identify What Can Be Cleaned
+
+Check for cleanable items:
+
+```bash
+echo "=== Analyzing Cleanable Items ==="
+```
+
+```bash
+echo "" && echo "Debug logs older than 7 days:" && find ~/.claude/debug -name "*.log" -mtime +7 2>/dev/null | wc -l
+```
+
+```bash
+echo "" && echo "Shell snapshots older than 7 days:" && find ~/.claude/shell-snapshots -mtime +7 2>/dev/null | wc -l
+```
+
+```bash
+echo "" && echo "File history older than 30 days:" && find ~/.claude/file-history -mtime +30 2>/dev/null | wc -l
+```
+
+```bash
+echo "" && echo "Temporary files:" && du -sh ~/.claude/tmp 2>/dev/null || echo "No temp directory"
+```
+
+### Step 4: Calculate Potential Space Savings
+
+Show how much space would be freed:
+
+```bash
+echo "=== Potential Space to Free ===" && echo ""
+```
+
+```bash
+echo "From old debug logs:" && find ~/.claude/debug -name "*.log" -mtime +7 -exec du -sk {} + 2>/dev/null | awk '{sum+=$1} END {if(sum) print sum/1024 " MB"; else print "0 MB"}'
+```
+
+```bash
+echo "" && echo "From old shell snapshots:" && find ~/.claude/shell-snapshots -mtime +7 -exec du -sk {} + 2>/dev/null | awk '{sum+=$1} END {if(sum) print sum/1024 " MB"; else print "0 MB"}'
+```
+
+```bash
+echo "" && echo "From old file history:" && find ~/.claude/file-history -mtime +30 -exec du -sk {} + 2>/dev/null | awk '{sum+=$1} END {if(sum) print sum/1024 " MB"; else print "0 MB"}'
+```
+
+## Analysis Complete
+
+**STOP HERE and show the user the analysis results above.**
+
+**Do NOT proceed to Step 5 or Step 6 without explicit user confirmation.**
+
+Ask the user: "Would you like to proceed with regular clean (removes old logs/snapshots/temp files)?"
+
+---
+
+### Step 5: Regular Clean (Only After User Says YES)
+
+**⚠️ ONLY execute these commands if the user explicitly confirmed above.**
+
+**Clean debug logs older than 7 days:**
+```bash
+find ~/.claude/debug -name "*.log" -mtime +7 -delete 2>/dev/null && echo "✓ Cleaned old debug logs"
+```
+
+**Clean shell snapshots older than 7 days:**
+```bash
+find ~/.claude/shell-snapshots -mtime +7 -delete 2>/dev/null && echo "✓ Cleaned old shell snapshots"
+```
+
+**Clean file history older than 30 days:**
+```bash
+find ~/.claude/file-history -mtime +30 -delete 2>/dev/null && echo "✓ Cleaned old file history"
+```
+
+**Clean temporary files:**
+```bash
+rm -rf ~/.claude/tmp/* 2>/dev/null && echo "✓ Cleaned temporary files"
+```
+
+**Show new size after regular clean:**
+```bash
+echo "" && echo "=== After Regular Clean ===" && du -sh ~/.claude 2>/dev/null
+```
+
+---
+
+### Step 6: Deep Clean (Only After Explicit User Confirmation)
+
+**⚠️ WARNING: Deep clean removes project caches and may slow down first project load.**
+
+**STOP and ask the user explicitly:** "Do you want to proceed with DEEP clean? This removes project caches and command history. (yes/no)"
+
+**⚠️ ONLY execute these commands if the user explicitly says YES to deep clean.**
+
+**Remove all project caches:**
+```bash
+du -sh ~/.claude/projects 2>/dev/null && echo "" && echo "Removing project caches..." && rm -rf ~/.claude/projects/* 2>/dev/null && echo "✓ Cleaned project caches"
+```
+
+**Remove old proxy databases (keep latest only):**
+```bash
+ls -t ~/.claude/local/*.db 2>/dev/null | tail -n +2 | xargs -r du -sk 2>/dev/null | awk '{sum+=$1} END {if(sum) print "Freeing " sum/1024 " MB from old proxy DBs"}'
+```
+
+```bash
+ls -t ~/.claude/local/*.db 2>/dev/null | tail -n +2 | xargs -r rm 2>/dev/null && echo "✓ Cleaned old proxy databases"
+```
+
+**Clear command history:**
+```bash
+du -sh ~/.claude/history.jsonl 2>/dev/null && echo "" && > ~/.claude/history.jsonl && echo "✓ Cleared command history"
+```
+
+**Show final size after deep clean:**
+```bash
+echo "" && echo "=== After Deep Clean ===" && du -sh ~/.claude 2>/dev/null
+```
+
+## Expected Behavior
+
+After running this command:
+
+1. **Analysis phase** (Steps 1-4): Read-only, shows:
+   - Current disk usage
+   - Breakdown by directory
+   - What can be cleaned
+   - Potential space savings
+
+2. **Regular clean** (Step 5): Removes (with user confirmation):
+   - Debug logs older than 7 days
+   - Shell snapshots older than 7 days
+   - File history older than 30 days
+   - Temporary files
+
+3. **Deep clean** (Step 6): Removes (with explicit user confirmation):
+   - All project caches
+   - Old proxy databases (keeps latest)
+   - Command history
+
+## Safety Notes
+
+- Analysis steps (1-4) are 100% read-only
+- Regular clean is safe - only removes old/temporary files
+- Deep clean requires explicit confirmation - removes caches
+- Always shows disk usage before and after
+- If ~/.claude doesn't exist, reports this and exits
+- Uses `find -delete` which is safer than `rm -rf` for specific patterns

--- a/.claude/commands/diagnose-skills.md
+++ b/.claude/commands/diagnose-skills.md
@@ -1,0 +1,273 @@
+---
+description: Diagnose why Skills aren't working - check structure, permissions, and discoverability
+---
+
+## Your Task
+
+Help users troubleshoot why their Claude Code Skills aren't being discovered or invoked. This addresses common issues found in GitHub issues #11459, #9716, #11322, and #10067.
+
+**Related Issues:**
+- [#11459](https://github.com/anthropics/claude-code/issues/11459) - Skills being interpreted as slash commands
+- [#9716](https://github.com/anthropics/claude-code/issues/9716) - Skills not being discovered
+- [#11322](https://github.com/anthropics/claude-code/issues/11322) - Prettier formatting breaks skill frontmatter
+- [#10067](https://github.com/anthropics/claude-code/issues/10067) - Skill architecture differences
+
+## Diagnostic Workflow
+
+### Step 1: Check if Skills Exist
+
+```bash
+echo "=== Checking for Skills ==="
+```
+
+```bash
+if [ -d .claude/skills ]; then echo "✓ Project skills directory exists (.claude/skills/)"; else echo "✗ No project skills directory found"; fi
+```
+
+```bash
+if [ -d ~/.claude/skills ]; then echo "✓ Global skills directory exists (~/.claude/skills/)"; else echo "✗ No global skills directory found"; fi
+```
+
+```bash
+echo "" && echo "=== Project Skills Found ===" && find .claude/skills -name "SKILL.md" -o -name "skill.md" 2>/dev/null | head -20 || echo "No SKILL.md files found in .claude/skills/"
+```
+
+```bash
+echo "" && echo "=== Global Skills Found ===" && find ~/.claude/skills -name "SKILL.md" -o -name "skill.md" 2>/dev/null | head -20 || echo "No SKILL.md files found in ~/.claude/skills/"
+```
+
+### Step 2: Validate Skill Structure
+
+For each skill found, check:
+
+**Required structure:**
+```
+.claude/skills/skill-name/
+└── SKILL.md (or skill.md)
+```
+
+**Common mistake #1: Wrong filename**
+- ❌ `.claude/skills/my-skill.md` (file at wrong level)
+- ✓ `.claude/skills/my-skill/SKILL.md` (correct)
+
+**Common mistake #2: Case sensitivity**
+- ✓ `SKILL.md` (preferred)
+- ✓ `skill.md` (also works)
+- ❌ `Skill.md` or `SKill.md` (may not work)
+
+Check if users have these issues:
+
+```bash
+echo "" && echo "=== Checking for Common Structure Issues ===" && echo ""
+```
+
+```bash
+echo "Files in wrong location (should be in subdirectories):" && find .claude/skills -maxdepth 1 -name "*.md" -type f 2>/dev/null || echo "None found (good!)"
+```
+
+```bash
+echo "" && echo "Skills with incorrect case:" && find .claude/skills -name "*.md" -type f 2>/dev/null | grep -v "SKILL.md" | grep -v "skill.md" || echo "None found (good!)"
+```
+
+### Step 3: Validate Frontmatter
+
+**Required YAML frontmatter:**
+```yaml
+---
+name: skill-name
+description: Clear description of what this skill does
+---
+```
+
+**Common mistake #3: Prettier formatting breaks multi-line descriptions**
+
+Check the first skill for frontmatter issues:
+
+```bash
+echo "" && echo "=== Checking Frontmatter Format ===" && echo ""
+```
+
+**If skills were found in Step 1, manually check one of them:**
+
+```bash
+find .claude/skills -name "SKILL.md" -o -name "skill.md" 2>/dev/null | head -1
+```
+
+**Then read that file:**
+
+Use the Read tool to examine the frontmatter of the skill file shown above.
+
+**Analyze the frontmatter and look for:**
+
+1. **Missing pipe operator on multi-line descriptions:**
+   ```yaml
+   # ❌ BROKEN (Prettier does this)
+   description:
+     This is a long description that was wrapped
+     by Prettier without a pipe operator
+
+   # ✓ FIXED
+   description: |
+     This is a long description that was wrapped
+     by Prettier with a pipe operator
+   ```
+
+2. **Missing name or description fields:**
+   ```yaml
+   # ❌ BROKEN
+   ---
+   title: my-skill
+   ---
+
+   # ✓ CORRECT
+   ---
+   name: my-skill
+   description: What this skill does
+   ---
+   ```
+
+### Step 4: Check Permissions
+
+Skills require Read permissions to access SKILL.md files.
+
+```bash
+echo "" && echo "=== Checking Permission Configuration ===" && echo ""
+```
+
+```bash
+if [ -f .claude/settings.json ]; then echo "Project settings exist" && cat .claude/settings.json 2>/dev/null | grep -A 10 "permissions" || echo "No permissions configured in project settings"; else echo "No project settings.json"; fi
+```
+
+```bash
+echo "" && if [ -f ~/.claude/settings.json ]; then echo "Global settings exist" && cat ~/.claude/settings.json 2>/dev/null | grep -A 10 "permissions" || echo "No permissions configured in global settings"; else echo "No global settings.json"; fi
+```
+
+**Common mistake #4: Skills directory in deny list**
+
+If you see permissions like:
+```json
+{
+  "permissions": {
+    "deny": [
+      "Read(~/.claude/**)",
+      "Read(.claude/**)"
+    ]
+  }
+}
+```
+
+**This will block Skills!** Skills need to read their SKILL.md files from `.claude/skills/` or `~/.claude/skills/`.
+
+**Fix:** Allow skill directories specifically:
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read(.claude/skills/**)",
+      "Read(~/.claude/skills/**)"
+    ],
+    "deny": [
+      "Read(.claude/project-caches/**)",
+      "Read(~/.claude/logs/**)"
+    ]
+  }
+}
+```
+
+### Step 5: Check for Slash Command Conflicts
+
+**Common mistake #5: Skills being interpreted as slash commands** (Issue #11459)
+
+```bash
+echo "" && echo "=== Checking for Slash Command Conflicts ===" && echo ""
+```
+
+```bash
+echo "Slash commands in .claude/commands/:" && find .claude/commands -name "*.md" -type f 2>/dev/null | sed 's|.claude/commands/||' | sed 's|.md$||' | sed 's|/|:|g' | sed 's|^|/|' || echo "No slash commands found"
+```
+
+```bash
+echo "" && echo "Skills in .claude/skills/:" && find .claude/skills -type d -mindepth 1 -maxdepth 1 2>/dev/null | sed 's|.claude/skills/||' || echo "No skills found"
+```
+
+**If you see the same name in both lists, that's a conflict!**
+
+Example conflict:
+- `.claude/commands/my-tool.md` → `/my-tool` slash command
+- `.claude/skills/my-tool/SKILL.md` → `my-tool` skill
+
+**Fix:** Rename either the slash command or the skill to avoid confusion.
+
+### Step 6: Test Skill Discovery
+
+Ask the user to restart Claude Code and then ask:
+
+**"What skills do you have available?"**
+
+If skills don't appear:
+1. ✅ Verified SKILL.md files exist in correct locations (Step 1)
+2. ✅ Verified frontmatter has `name:` and `description:` fields (Step 3)
+3. ✅ Fixed multi-line descriptions with `|` operator (Step 3)
+4. ✅ Allowed `.claude/skills/` in permissions (Step 4)
+5. ✅ No conflicts with slash commands (Step 5)
+
+**If all checks pass but skills still don't work:**
+- This may be a bug in Claude Code's skill discovery
+- Ask user to file a GitHub issue with the diagnostic output
+- Reference issues #11459, #9716, or #10067
+
+## Common Issues Summary
+
+| Issue | Symptom | Fix |
+|-------|---------|-----|
+| **Wrong structure** | Skill not discovered | Move to `.claude/skills/name/SKILL.md` |
+| **Prettier formatting** | Skill works, then stops after formatting | Add `\|` to multi-line descriptions |
+| **Permissions** | Skill not accessible | Allow `Read(.claude/skills/**)` |
+| **Slash command conflict** | Skill appears as `/command` | Rename skill or command |
+| **Missing frontmatter** | Skill not discovered | Add `name:` and `description:` fields |
+| **Case sensitivity** | Skill not discovered | Use `SKILL.md` (uppercase) |
+
+## Expected Output
+
+After running this diagnostic, you should:
+
+1. ✅ Know if skills exist and where they are
+2. ✅ Identify structure problems (wrong directories, wrong filenames)
+3. ✅ Identify frontmatter problems (Prettier formatting, missing fields)
+4. ✅ Identify permission problems (deny rules blocking skills)
+5. ✅ Identify conflicts with slash commands
+6. ✅ Have concrete steps to fix each problem
+
+## To Fix Common Issues
+
+**Prettier formatting breaking frontmatter:**
+```yaml
+# Add pipe operator
+description: |
+  Long description that spans
+  multiple lines
+```
+
+**Skills blocked by permissions:**
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read(.claude/skills/**)"
+    ]
+  }
+}
+```
+
+**Wrong structure:**
+```bash
+# Move from wrong location
+mv .claude/skills/my-skill.md .claude/skills/my-skill/SKILL.md
+```
+
+## Documentation References
+
+- [Official Skills Documentation](https://docs.claude.com/en/docs/claude-code/skills)
+- [GitHub Issue #11459](https://github.com/anthropics/claude-code/issues/11459) - Skills as slash commands
+- [GitHub Issue #11322](https://github.com/anthropics/claude-code/issues/11322) - Prettier formatting
+- [GitHub Issue #9716](https://github.com/anthropics/claude-code/issues/9716) - Skill discovery

--- a/.claude/commands/init-skills.md
+++ b/.claude/commands/init-skills.md
@@ -1,0 +1,181 @@
+---
+description: Initialize CLAUDE.md with skill-aware codebase analysis (checks for available Skills before file exploration)
+---
+
+## Your Task
+
+Analyze this codebase to create or update a comprehensive CLAUDE.md file that provides project context. **IMPORTANT:** Check for available Skills first before manually exploring files.
+
+**Related:** This addresses GitHub issue [#11661](https://github.com/anthropics/claude-code/issues/11661) - using Skills before manual file exploration.
+
+## Analysis Workflow
+
+### Phase 1: Check for Available Skills (PRIORITY)
+
+**Before exploring any files manually**, check if any Skills provide organized project knowledge:
+
+1. **List available Skills** in the current project:
+   ```bash
+   # Check for project skills
+   if [ -d .claude/skills ]; then
+     echo "=== Project Skills Available ==="
+     find .claude/skills -name "SKILL.md" -type f | sed 's|.claude/skills/||' | sed 's|/SKILL.md||'
+   else
+     echo "No project skills found in .claude/skills/"
+   fi
+   ```
+
+2. **Check global skills**:
+   ```bash
+   # Check for global skills
+   if [ -d ~/.claude/skills ]; then
+     echo ""
+     echo "=== Global Skills Available ==="
+     find ~/.claude/skills -name "SKILL.md" -type f | sed 's|'$HOME'/.claude/skills/||' | sed 's|/SKILL.md||'
+   else
+     echo "No global skills found in ~/.claude/skills/"
+   fi
+   ```
+
+3. **If Skills are found**: Use them by invoking the Skill tool with each discovered skill name
+   - Skills provide pre-synthesized project knowledge
+   - They're specifically designed for understanding architecture and context
+   - This is more efficient than reading files individually
+
+4. **If no Skills are found**: Proceed to Phase 2 for manual exploration
+
+### Phase 2: Manual Codebase Exploration (Fallback)
+
+**Only use this phase if no relevant Skills were found in Phase 1.**
+
+#### Step 1: Understand Project Structure
+
+```bash
+# Get high-level directory structure
+echo "=== Project Structure ==="
+tree -L 2 -d -I 'node_modules|venv|.git|__pycache__|dist|build' 2>/dev/null || find . -maxdepth 2 -type d -not -path '*/\.*' -not -path '*/node_modules/*' -not -path '*/venv/*' | head -20
+
+echo ""
+echo "=== File Count by Type ==="
+find . -type f -not -path '*/\.*' -not -path '*/node_modules/*' -not -path '*/venv/*' 2>/dev/null | sed 's/.*\.//' | sort | uniq -c | sort -rn | head -10
+```
+
+#### Step 2: Identify Core Files
+
+```bash
+# Find README and documentation
+echo "=== Documentation Files ==="
+find . -maxdepth 3 -type f \( -name "README*" -o -name "CONTRIBUTING*" -o -name "ARCHITECTURE*" \) -not -path '*/node_modules/*' 2>/dev/null
+
+# Find package/dependency files
+echo ""
+echo "=== Package Configuration ==="
+find . -maxdepth 3 -type f \( -name "package.json" -o -name "pyproject.toml" -o -name "Cargo.toml" -o -name "go.mod" -o -name "pom.xml" -o -name "build.gradle" \) 2>/dev/null
+```
+
+#### Step 3: Read Key Files
+
+Read and analyze (in this priority order):
+1. README.md or README.rst
+2. package.json / pyproject.toml / Cargo.toml / go.mod (for dependencies)
+3. CONTRIBUTING.md or ARCHITECTURE.md (if exists)
+4. Main entry points (e.g., src/main.*, src/index.*, main.py)
+
+#### Step 4: Analyze Code Structure
+
+```bash
+# Find main source directories
+echo "=== Source Code Organization ==="
+find . -type d \( -name "src" -o -name "lib" -o -name "pkg" -o -name "app" \) -not -path '*/node_modules/*' -not -path '*/venv/*' -maxdepth 3 2>/dev/null
+
+# Identify test directories
+echo ""
+echo "=== Test Organization ==="
+find . -type d \( -name "test" -o -name "tests" -o -name "__tests__" -o -name "spec" \) -not -path '*/node_modules/*' -maxdepth 3 2>/dev/null
+```
+
+### Phase 3: Generate CLAUDE.md
+
+Create a comprehensive CLAUDE.md with these sections:
+
+```markdown
+# Project Context for Claude Code
+
+## Project Overview
+[Brief description of what this project does]
+
+## Technology Stack
+[Languages, frameworks, key dependencies]
+
+## Project Structure
+[Directory organization and key modules]
+
+## Development Workflow
+[Common commands, build process, testing]
+
+## Architecture
+[High-level architecture decisions, patterns used]
+
+## Key Files and Their Purpose
+[Important files and what they do]
+
+## Common Tasks
+[Frequent development operations]
+
+## Conventions
+[Code style, naming conventions, patterns]
+
+## External Dependencies
+[Key libraries and their purposes]
+
+## Notes for Claude Code
+[Specific guidance for AI assistance - e.g., "always run tests before committing"]
+```
+
+## Key Differences from Standard /init
+
+1. **Skills-First Approach**: Checks for and uses Skills before manual exploration
+2. **More Efficient**: Leverages pre-synthesized knowledge when available
+3. **Better Context**: Skills are specifically designed for project context
+4. **Fallback Support**: Still explores manually if no Skills exist
+
+## Expected Behavior
+
+### If Skills Are Found:
+1. Discover available Skills
+2. Invoke relevant Skills to gather project knowledge
+3. Synthesize information from Skills into CLAUDE.md
+4. Supplement with targeted file reads only for gaps
+
+### If No Skills Are Found:
+1. Report that no Skills were discovered
+2. Fall back to systematic file exploration
+3. Read key documentation and configuration files
+4. Analyze project structure and dependencies
+5. Generate CLAUDE.md from gathered information
+
+## Success Criteria
+
+- [ ] Checked for Skills before exploring files
+- [ ] Used available Skills if found (or reported none exist)
+- [ ] Created/updated CLAUDE.md with comprehensive context
+- [ ] Included project structure, tech stack, and workflows
+- [ ] Documented common tasks and conventions
+- [ ] Added AI-specific guidance in "Notes for Claude Code" section
+
+## Why This Approach Is Better
+
+**From GitHub issue #11661:**
+
+> Skills align with Anthropic's documented use cases:
+> - "Execute company-specific data analysis workflows"
+> - "Automate personal workflows and customize Claude to match your work style"
+>
+> The `/init` task (understanding architecture, identifying common commands, synthesizing documentation)
+> directly matches what project-specific Skills are designed to provide.
+
+Using Skills first:
+- ✅ More efficient context usage
+- ✅ Faster analysis
+- ✅ Leverages pre-synthesized knowledge
+- ✅ Better alignment with Skills' intended purpose

--- a/.claude/commands/label-session.md
+++ b/.claude/commands/label-session.md
@@ -1,0 +1,218 @@
+---
+description: Add or update a user-friendly label for a Claude Code session
+---
+
+## Your Task
+
+**Extract** the session ID and label from the user's request, then **store** it in `~/.claude/session-labels.json` for use with `/list-sessions`.
+
+**IMPORTANT:**
+- Session ID must be a valid UUID format (e.g., `7ee51d83-6cdd-444e-a074-865dee92bd18`)
+- Label should be descriptive and brief (e.g., "Fix auth bug", "Refactor API")
+- Creates `~/.claude/session-labels.json` if it doesn't exist
+- Updates existing labels without losing other session data
+
+## Context
+
+Issue #3605 requests session renaming functionality. Since Claude Code stores session metadata in a database that we cannot safely modify, this command provides a **workaround** by maintaining a separate labels file.
+
+**How it works:**
+1. User provides: `/label-session <session-id> <label>`
+2. Command stores mapping in `~/.claude/session-labels.json`
+3. `/list-sessions` reads and displays these labels
+4. Non-destructive: doesn't modify Claude Code's internal database
+
+**File format** (`~/.claude/session-labels.json`):
+```json
+{
+  "session-id-here": {
+    "label": "User-friendly name",
+    "created": "2025-11-16T15:45:00Z",
+    "updated": "2025-11-16T16:20:00Z"
+  }
+}
+```
+
+## Usage Examples
+
+```bash
+# Label the current session
+/label-session 7ee51d83-6cdd-444e-a074-865dee92bd18 "Developer utilities plugin"
+
+# Update an existing label
+/label-session fccea55b-62b9-447d-ac21-76c04e32aece "Fix auth bug - completed"
+
+# Use quotes for multi-word labels
+/label-session abc-123 "Refactor authentication system"
+```
+
+## Commands to Execute
+
+### Step 1: Parse user input
+
+Extract session ID and label from the user's message. The user should provide:
+- Session ID (36 character UUID)
+- Label (remaining text after session ID)
+
+**Ask the user** to provide these if not already given:
+
+```
+Please provide the session ID and label in this format:
+/label-session <session-id> <label>
+
+Example:
+/label-session 7ee51d83-6cdd-444e-a074-865dee92bd18 "Working on auth system"
+
+To find your session ID, use /list-sessions
+```
+
+### Step 2: Validate session ID format
+
+Once you have the session ID, validate it's a proper UUID:
+
+```bash
+SESSION_ID="<user-provided-session-id>" && if echo "$SESSION_ID" | grep -E '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$' >/dev/null 2>&1; then echo "Valid session ID: $SESSION_ID"; else echo "ERROR: Invalid session ID format. Must be a UUID like: 7ee51d83-6cdd-444e-a074-865dee92bd18"; exit 1; fi
+```
+
+### Step 3: Verify session exists in history
+
+Check if the session ID exists in history.jsonl:
+
+```bash
+SESSION_ID="<user-provided-session-id>" && if grep -q "\"sessionId\":\"$SESSION_ID\"" ~/.claude/history.jsonl 2>/dev/null; then echo "Session found in history"; else echo "WARNING: Session ID not found in ~/.claude/history.jsonl. The label will be saved but may not correspond to an active session."; fi
+```
+
+### Step 4: Create or update labels file
+
+Create the labels file if it doesn't exist, or update it with the new label:
+
+```bash
+LABELS_FILE=~/.claude/session-labels.json && SESSION_ID="<user-provided-session-id>" && LABEL="<user-provided-label>" && TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ") && if [ ! -f "$LABELS_FILE" ]; then echo '{}' > "$LABELS_FILE" && echo "Created new labels file: $LABELS_FILE"; fi && EXISTING_CREATED=$(jq -r --arg sid "$SESSION_ID" '.[$sid].created // ""' "$LABELS_FILE" 2>/dev/null) && if [ -z "$EXISTING_CREATED" ]; then CREATED="$TIMESTAMP"; else CREATED="$EXISTING_CREATED"; fi && jq --arg sid "$SESSION_ID" --arg label "$LABEL" --arg created "$CREATED" --arg updated "$TIMESTAMP" '.[$sid] = {label: $label, created: $created, updated: $updated}' "$LABELS_FILE" > "$LABELS_FILE.tmp" && mv "$LABELS_FILE.tmp" "$LABELS_FILE" && echo "" && echo "✓ Session labeled successfully!" && echo "" && echo "Session ID: $SESSION_ID" && echo "Label: $LABEL" && echo "Updated: $TIMESTAMP" && echo "" && echo "Use /list-sessions to see your labeled sessions."
+```
+
+### Step 5: Show the updated label
+
+Display the newly created or updated label:
+
+```bash
+LABELS_FILE=~/.claude/session-labels.json && SESSION_ID="<user-provided-session-id>" && if [ -f "$LABELS_FILE" ]; then echo "=== Session Label ===" && jq --arg sid "$SESSION_ID" '.[$sid]' "$LABELS_FILE"; else echo "Labels file not found"; fi
+```
+
+## What to Ask the User
+
+If the user runs `/label-session` without providing both session ID and label, ask:
+
+```
+I need two pieces of information to label a session:
+
+1. **Session ID** - The UUID of the session to label
+2. **Label** - A descriptive name for this session
+
+Format:
+/label-session <session-id> <label>
+
+Example:
+/label-session 7ee51d83-6cdd-444e-a074-865dee92bd18 "Developer utilities plugin work"
+
+---
+
+To find available session IDs, run: /list-sessions
+
+What session would you like to label?
+```
+
+## Expected User Response
+
+The user should provide:
+
+```
+/label-session 7ee51d83-6cdd-444e-a074-865dee92bd18 "Working on authentication bug"
+```
+
+Or they can provide the information conversationally:
+
+```
+Label session 7ee51d83-6cdd-444e-a074-865dee92bd18 as "API refactoring"
+```
+
+## Example Output
+
+After successfully labeling a session:
+
+```
+✓ Session labeled successfully!
+
+Session ID: 7ee51d83-6cdd-444e-a074-865dee92bd18
+Label: Developer utilities plugin work
+Updated: 2025-11-16T20:45:32Z
+
+Use /list-sessions to see your labeled sessions.
+```
+
+## Related Commands
+
+- `/list-sessions` - View all sessions with their labels
+- `/resume` - Resume a previous session (built-in)
+
+## Advanced Usage
+
+### Label the current session
+
+To label the session you're currently in, first find its ID:
+
+```bash
+cat ~/.claude/history.jsonl | jq -r '.sessionId' | tail -1
+```
+
+Then use that ID with `/label-session`.
+
+### Remove a label
+
+To remove a label, set it to an empty string:
+
+```
+/label-session abc-123 ""
+```
+
+Or manually edit `~/.claude/session-labels.json` and remove the entry.
+
+### Bulk labeling
+
+To label multiple sessions at once, manually edit `~/.claude/session-labels.json`:
+
+```json
+{
+  "session-1": {
+    "label": "Auth system work",
+    "created": "2025-11-16T20:00:00Z",
+    "updated": "2025-11-16T20:00:00Z"
+  },
+  "session-2": {
+    "label": "API refactoring",
+    "created": "2025-11-16T20:01:00Z",
+    "updated": "2025-11-16T20:01:00Z"
+  }
+}
+```
+
+## Troubleshooting
+
+**"Invalid session ID format"**
+- Session IDs must be UUIDs (36 characters with hyphens)
+- Get session IDs from `/list-sessions`
+
+**"Session ID not found in history"**
+- The session may be very old or from a different system
+- The label will still be saved but may not be useful
+
+**"jq: command not found"**
+- Install jq: `sudo apt install jq` (Ubuntu) or `brew install jq` (macOS)
+
+**Labels not showing in /list-sessions**
+- Verify `~/.claude/session-labels.json` exists and has valid JSON
+- Check file permissions: `ls -la ~/.claude/session-labels.json`
+
+## References
+
+- GitHub Issue: #3605 - Session renaming feature request
+- Note: This is a **workaround** since we cannot modify Claude Code's internal session database

--- a/.claude/commands/list-sessions.md
+++ b/.claude/commands/list-sessions.md
@@ -1,0 +1,157 @@
+---
+description: List Claude Code sessions with context, labels, and activity timeline
+---
+
+## Your Task
+
+**Display** all Claude Code sessions with timestamps, projects, activity counts, and user-defined labels to help identify and resume the right session.
+
+**IMPORTANT:**
+- Read-only analysis (safe to run anytime)
+- Shows sessions from `~/.claude/history.jsonl`
+- Displays user labels from `~/.claude/session-labels.json` if they exist
+- Sorted by most recent activity first
+
+## Context
+
+Claude Code sessions are stored in:
+- `~/.claude/history.jsonl` - All session activity with timestamps and projects
+- `~/.claude/session-env/[session-id]/` - Session environment directories
+- `~/.claude/session-labels.json` - User-defined labels (optional)
+
+Issue #3605 requests better session identification. This command addresses that by showing:
+- Session IDs (for use with /resume)
+- User labels (set with /label-session)
+- Project paths
+- First and last activity timestamps
+- Total interaction count
+- First user message (as context)
+
+## Commands to Execute
+
+### Step 1: Check if history.jsonl exists
+
+```bash
+if [ -f ~/.claude/history.jsonl ]; then echo "Found history file"; else echo "ERROR: ~/.claude/history.jsonl not found. No sessions to display."; exit 1; fi
+```
+
+### Step 2: Load session labels (if they exist)
+
+```bash
+LABELS_FILE=~/.claude/session-labels.json && if [ -f "$LABELS_FILE" ]; then echo "Labels file found at $LABELS_FILE"; else echo "No labels file yet. Use /label-session to create labels."; fi
+```
+
+### Step 3: Parse and display sessions
+
+Parse history.jsonl, group by sessionId, and display with labels:
+
+```bash
+cat ~/.claude/history.jsonl | jq -r '.sessionId' | sort | uniq -c | sort -rn | head -20
+```
+
+### Step 4: Create and run a script to display detailed session information
+
+Create a temporary script file to process the sessions (this avoids bash escaping issues):
+
+Use the Write tool to create `/tmp/list-claude-sessions.sh` with the following content:
+
+```bash
+#!/bin/bash
+echo "=== Claude Code Sessions (Most Recent First) ==="
+echo ""
+
+# Get last 20 unique sessions
+cat ~/.claude/history.jsonl | jq -r '.sessionId' | sort | uniq | tail -20 | tac | while read session_id; do
+  # Get session details
+  FIRST_TS=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\") | .timestamp" | head -1)
+  LAST_TS=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\") | .timestamp" | tail -1)
+  PROJECT=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\") | .project" | head -1)
+  COUNT=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\")" | wc -l)
+  FIRST_MSG=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\") | .display" | grep -v "^/StartOfTheDay" | grep -v "^$" | head -1 | cut -c1-60)
+
+  # Get label if exists
+  LABEL=""
+  if [ -f ~/.claude/session-labels.json ]; then
+    LABEL=$(jq -r --arg sid "$session_id" '.[$sid].label // ""' ~/.claude/session-labels.json 2>/dev/null)
+  fi
+
+  # Convert timestamps to dates
+  FIRST_DATE=$(date -d "@$((FIRST_TS/1000))" "+%Y-%m-%d %H:%M" 2>/dev/null || date -r "$((FIRST_TS/1000))" "+%Y-%m-%d %H:%M" 2>/dev/null)
+  LAST_DATE=$(date -d "@$((LAST_TS/1000))" "+%Y-%m-%d %H:%M" 2>/dev/null || date -r "$((LAST_TS/1000))" "+%Y-%m-%d %H:%M" 2>/dev/null)
+
+  # Display session info
+  echo "Session: $session_id"
+  if [ -n "$LABEL" ]; then
+    echo "  Label: $LABEL"
+  fi
+  echo "  Project: $PROJECT"
+  echo "  Started: $FIRST_DATE"
+  echo "  Last Activity: $LAST_DATE"
+  echo "  Interactions: $COUNT"
+  if [ -n "$FIRST_MSG" ]; then
+    echo "  First Message: $FIRST_MSG..."
+  fi
+  echo ""
+done
+```
+
+Then make it executable and run it:
+
+```bash
+chmod +x /tmp/list-claude-sessions.sh && /tmp/list-claude-sessions.sh
+```
+
+### Step 5: Show usage instructions
+
+```bash
+echo "=== Usage Instructions ===" && echo "" && echo "To resume a session:" && echo "  Type 'claude --resume' and select from the list" && echo "" && echo "To label a session:" && echo "  /label-session <session-id> <label>" && echo "  Example: /label-session 7ee51d83-6cdd-444e-a074-865dee92bd18 \"Fix auth bug\"" && echo "" && echo "To see all sessions:" && echo "  /list-sessions" && echo ""
+```
+
+## Output Format
+
+The command will display sessions like this:
+
+```
+=== Claude Code Sessions (Most Recent First) ===
+
+Session: 7ee51d83-6cdd-444e-a074-865dee92bd18
+  Label: Developer utilities plugin work
+  Project: /home/adam/Code/claude-code
+  Started: 2025-11-16 15:37
+  Last Activity: 2025-11-16 15:45
+  Interactions: 24
+  First Message: Is there a way to fix this? would this be a good ca...
+
+Session: fccea55b-62b9-447d-ac21-76c04e32aece
+  Project: /home/adam/Code/claude-code
+  Started: 2025-11-15 16:22
+  Last Activity: 2025-11-15 17:10
+  Interactions: 18
+  First Message: Review the developer-utilities plugin...
+```
+
+## Related Commands
+
+- `/label-session` - Add or update a label for a session
+- `/resume` - Resume a previous session (built-in Claude Code command)
+- `claude --resume` - Resume from CLI
+
+## Notes
+
+- Sessions are identified by UUID (e.g., `7ee51d83-6cdd-444e-a074-865dee92bd18`)
+- Labels are optional and stored in `~/.claude/session-labels.json`
+- Timestamps are converted from milliseconds to human-readable format
+- The first non-command message is shown for context
+- Limited to 20 most recent sessions for readability
+
+## Troubleshooting
+
+If sessions don't appear:
+- Check `~/.claude/history.jsonl` exists
+- Verify `jq` is installed: `which jq`
+- Check file permissions: `ls -la ~/.claude/history.jsonl`
+
+## References
+
+- GitHub Issue: #3605 - Session renaming feature request
+- Related: This addresses the "better session visualization" request

--- a/.claude/commands/permission-examples.md
+++ b/.claude/commands/permission-examples.md
@@ -1,0 +1,356 @@
+---
+description: Show permission examples using your actual settings and explain how allow/ask/deny rules work
+---
+
+## Your Task
+
+Help users understand how Claude Code permission rules work by showing their actual configuration and explaining the precedence rules.
+
+**Related:** This addresses GitHub issue [#11655](https://github.com/anthropics/claude-code/issues/11655) regarding unclear documentation on allow vs deny precedence.
+
+## Permission Rules Overview
+
+Claude Code evaluates permissions in this order:
+
+1. **DENY rules are checked first** - If matched, command is blocked
+2. **ALLOW rules are checked second** - If matched, command runs without asking
+3. **ASK rules are checked third** - If matched, user is prompted for approval
+4. **Default behavior** - If no rules match, user is prompted (same as ASK)
+
+**Key Principle: DENY takes precedence over ALLOW**
+
+## Step 1: Check Which Permission Files Exist
+
+Check for permission files:
+
+```bash
+echo "=== Permission Files Found ===" && echo ""
+```
+
+```bash
+if [ -f .claude/settings.json ] && grep -q "permissions" .claude/settings.json 2>/dev/null; then echo "✓ Project settings (.claude/settings.json)"; fi
+```
+
+```bash
+if [ -f ~/.claude/settings.json ] && grep -q "permissions" ~/.claude/settings.json 2>/dev/null; then echo "✓ Global settings (~/.claude/settings.json)"; fi
+```
+
+```bash
+if [ -f .claude/settings.local.json ] && grep -q "permissions" .claude/settings.local.json 2>/dev/null; then echo "✓ Local settings (.claude/settings.local.json)"; fi
+```
+
+## Step 2: Ask User Which Settings to Show (If Multiple Exist)
+
+**Count how many permission files exist from Step 1.**
+
+**If 2 or more files have permissions:**
+- Ask the user: "I found multiple permission configurations. Which would you like me to explain? (project/global/local)"
+- Show only the one they choose
+- Skip to Step 3 with their choice
+
+**If exactly 1 file has permissions:**
+- Automatically use that one
+- Proceed to Step 3
+
+**If 0 files have permissions:**
+- Skip to Step 4 (show hard-coded examples)
+
+## Step 3: Show User's Actual Permissions with Explanations
+
+**Based on which file the user selected (or the only one that exists):**
+
+**For Project settings (.claude/settings.json):**
+
+```bash
+echo "=== Your Project Permissions ===" && echo ""
+```
+
+```bash
+cat .claude/settings.json 2>/dev/null | grep -A 50 "permissions"
+```
+
+```bash
+echo "" && echo "=== How These Rules Work ===" && echo ""
+```
+
+**Then explain their specific rules:**
+- Look at their actual allow/ask/deny arrays
+- Explain what each rule means
+- Point out if DENY rules override ALLOW rules
+- Show examples of commands that would match each rule
+
+**For Global settings (~/.claude/settings.json):**
+
+```bash
+echo "=== Your Global Permissions ===" && echo ""
+```
+
+```bash
+cat ~/.claude/settings.json 2>/dev/null | grep -A 50 "permissions"
+```
+
+```bash
+echo "" && echo "=== How These Rules Work ===" && echo ""
+```
+
+**Then explain their specific rules** (same as above)
+
+**For Local settings (.claude/settings.local.json):**
+
+```bash
+echo "=== Your Local Permissions ===" && echo ""
+```
+
+```bash
+cat .claude/settings.local.json 2>/dev/null | grep -A 50 "permissions"
+```
+
+```bash
+echo "" && echo "=== How These Rules Work ===" && echo ""
+```
+
+**Then explain their specific rules** (same as above)
+
+### Explanation Template
+
+After showing their permissions, analyze and explain:
+
+1. **ALLOW rules**: "These commands will run without asking:"
+   - List each allow rule and what it matches
+
+2. **ASK rules**: "These commands will prompt for confirmation:"
+   - List each ask rule and what it matches
+
+3. **DENY rules**: "These commands are blocked:"
+   - List each deny rule and what it matches
+   - If any DENY rules conflict with ALLOW rules, point this out
+
+4. **Precedence conflicts**: Check if any rules conflict
+   - Example: If they have `Bash(*)` in deny AND `Bash(ls:*)` in allow, explain that the deny wins
+
+## Step 4: Show Hard-Coded Examples (Only If No Permissions Configured)
+
+**Only run this step if NO permission files were found in Step 1.**
+
+```bash
+echo "=== No Permissions Configured ===" && echo ""
+```
+
+```bash
+echo "You don't have any permissions configured yet. Here are some common examples:"
+```
+
+### Example 1: Deny Takes Precedence
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(pwd)"
+    ],
+    "deny": [
+      "Bash(*)"
+    ]
+  }
+}
+```
+
+**Result:** All Bash commands are DENIED (deny overrides allow)
+
+**Explanation:** Even though `ls` and `pwd` are in the allow list, the broader `Bash(*)` deny rule blocks ALL bash commands.
+
+---
+
+### Example 2: Specific Deny with General Allow
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(*)"
+    ],
+    "deny": [
+      "Bash(rm:*)",
+      "Bash(curl:*)",
+      "Bash(wget:*)"
+    ]
+  }
+}
+```
+
+**Result:** Most Bash commands are allowed, but rm/curl/wget are denied
+
+**Explanation:** The allow rule permits all bash commands, but specific deny rules block dangerous operations.
+
+---
+
+### Example 3: File Access Control
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read(*)"
+    ],
+    "deny": [
+      "Read(.env)",
+      "Read(secrets/**)",
+      "Read(**/*.key)",
+      "Read(**/*.pem)"
+    ]
+  }
+}
+```
+
+**Result:** Can read most files, but .env, secrets/, and key/pem files are blocked
+
+**Explanation:** Broad file reading access with specific security-sensitive files denied.
+
+---
+
+### Example 4: Git Workflow Protection
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(git commit:*)",
+      "Bash(git merge:*)"
+    ],
+    "deny": [
+      "Bash(git push --force:*)",
+      "Bash(rm:*)"
+    ]
+  }
+}
+```
+
+**Result:**
+- Read-only git commands are auto-allowed
+- Write git commands require confirmation
+- Force push and rm are completely blocked
+
+---
+
+## Step 5: Test Safe Commands (Optional)
+
+Test that permissions are working with safe commands:
+
+```bash
+echo "=== Testing Safe Commands ===" && echo ""
+```
+
+```bash
+echo "Test 1: echo (usually allowed)" && echo "Hello, permissions!"
+```
+
+```bash
+echo "" && echo "Test 2: pwd (usually allowed)" && pwd
+```
+
+```bash
+echo "" && echo "Test 3: git status (safe, read-only)" && git status --short
+```
+
+If these commands run without prompting, they're in your ALLOW list.
+If you get a prompt, they're in your ASK list or not configured.
+If they're blocked, they're in your DENY list.
+
+## Permission Rule Syntax Reference
+
+### Tool Patterns
+
+| Pattern | Matches | Example |
+|---------|---------|---------|
+| `ToolName` | Exact tool | `WebFetch` blocks all web fetches |
+| `ToolName(*)` | Tool with any args | `Bash(*)` matches all bash commands |
+| `ToolName(pattern:*)` | Prefix match | `Bash(git:*)` matches git commands |
+| `Read(path/**)` | Glob patterns | `Read(secrets/**)` matches all files in secrets/ |
+
+### Important Notes
+
+1. **Bash uses prefix matching**, not regex
+   - `Bash(git:*)` matches `git status`, `git commit`, etc.
+   - But prefix matching can be bypassed (see security limitations)
+
+2. **More specific rules should be in DENY**
+   - Deny specific dangerous operations
+   - Allow broader categories
+
+3. **DENY always wins**
+   - If a command matches both DENY and ALLOW, it's denied
+   - Order in the file doesn't matter - DENY is checked first
+
+## Common Configurations
+
+### Development Environment (Permissive)
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "Read(*)",
+      "Write(*)",
+      "Edit(*)"
+    ],
+    "ask": [
+      "Bash(git push:*)"
+    ],
+    "deny": [
+      "Bash(rm -rf /*)"
+    ]
+  }
+}
+```
+
+### Production Environment (Restrictive)
+```json
+{
+  "permissions": {
+    "allow": [
+      "Read(*)",
+      "Bash(git status)",
+      "Bash(git diff:*)"
+    ],
+    "ask": [
+      "Bash(git:*)",
+      "Edit(*)",
+      "Write(*)"
+    ],
+    "deny": [
+      "Bash(rm:*)",
+      "Bash(curl:*)",
+      "WebFetch",
+      "Read(.env)",
+      "Read(secrets/**)"
+    ]
+  }
+}
+```
+
+## Expected Behavior
+
+After running this command, you will understand:
+
+1. **Your current configuration** (if any exists)
+2. **Precedence order:** DENY → ALLOW → ASK → Default (ask)
+3. **How to configure permissions** for different security needs
+4. **Pattern matching syntax** for different tools
+5. **Common gotchas** and best practices
+
+## To Modify Permissions
+
+Use the built-in `/permissions` command to interactively configure your permission rules.
+
+## Documentation References
+
+- [Official Permissions Documentation](https://code.claude.com/docs/en/settings#permission-settings)
+- [IAM & Security](https://code.claude.com/docs/en/iam)
+- [GitHub Issue #11655](https://github.com/anthropics/claude-code/issues/11655) - Permission precedence clarification

--- a/.claude/commands/resume-session.md
+++ b/.claude/commands/resume-session.md
@@ -1,0 +1,202 @@
+---
+description: Resume a Claude Code session with an interactive picker showing labels
+---
+
+## Your Task
+
+**Display** an interactive menu of recent sessions with their labels, then **resume** the selected session.
+
+This command provides a better alternative to `claude --resume` by showing your custom labels.
+
+## How It Works
+
+1. Parse recent sessions from `~/.claude/history.jsonl`
+2. Load labels from `~/.claude/session-labels.json`
+3. Display an interactive menu using `fzf` (fuzzy finder)
+4. Resume the selected session
+
+## Commands to Execute
+
+### Step 1: Check dependencies
+
+Check if `fzf` is installed (needed for interactive picker):
+
+```bash
+if command -v fzf >/dev/null 2>&1; then echo "fzf is installed"; else echo "ERROR: fzf is required but not installed. Install with: sudo apt install fzf"; exit 1; fi
+```
+
+### Step 2: Create the picker script
+
+Use the Write tool to create `/tmp/resume-claude-session.sh` with the following content:
+
+```bash
+#!/bin/bash
+
+# Create a temporary file for session list
+SESSIONS_FILE="/tmp/claude-sessions-$$.txt"
+
+# Get last 20 unique sessions with details
+cat ~/.claude/history.jsonl | jq -r '.sessionId' | sort | uniq | tail -20 | tac | while read session_id; do
+  # Skip null sessions
+  if [ "$session_id" = "null" ]; then
+    continue
+  fi
+
+  # Get session details
+  FIRST_TS=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\") | .timestamp" | head -1)
+  LAST_TS=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\") | .timestamp" | tail -1)
+  PROJECT=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\") | .project" | head -1)
+  FIRST_MSG=$(cat ~/.claude/history.jsonl | jq -r "select(.sessionId==\"$session_id\") | .display" | grep -v "^/StartOfTheDay" | grep -v "^$" | head -1 | cut -c1-40)
+
+  # Get label if exists
+  LABEL=""
+  if [ -f ~/.claude/session-labels.json ]; then
+    LABEL=$(jq -r --arg sid "$session_id" '.[$sid].label // ""' ~/.claude/session-labels.json 2>/dev/null)
+  fi
+
+  # Convert timestamp to relative time
+  LAST_DATE=$(date -d "@$((LAST_TS/1000))" "+%Y-%m-%d %H:%M" 2>/dev/null || date -r "$((LAST_TS/1000))" "+%Y-%m-%d %H:%M" 2>/dev/null)
+
+  # Use label if available, otherwise first message
+  DISPLAY_NAME="$LABEL"
+  if [ -z "$DISPLAY_NAME" ]; then
+    DISPLAY_NAME="$FIRST_MSG"
+  fi
+
+  # Get project basename
+  PROJECT_NAME=$(basename "$PROJECT")
+
+  # Format: [Label/Message] · [Project] · [Date] · [SessionID]
+  echo "$DISPLAY_NAME · $PROJECT_NAME · $LAST_DATE · $session_id"
+done > "$SESSIONS_FILE"
+
+# Check if we have any sessions
+if [ ! -s "$SESSIONS_FILE" ]; then
+  echo "No sessions found in ~/.claude/history.jsonl"
+  rm -f "$SESSIONS_FILE"
+  exit 1
+fi
+
+# Show picker with fzf
+echo "Select a session to resume (Ctrl+C to cancel):"
+echo ""
+
+SELECTION=$(cat "$SESSIONS_FILE" | fzf \
+  --height=20 \
+  --border \
+  --header="Recent Claude Code Sessions (with labels)" \
+  --preview='echo {}' \
+  --preview-window=hidden \
+  --prompt="Resume session: " \
+  --pointer="→" \
+  --color="header:italic:underline,prompt:blue,pointer:green")
+
+# Clean up temp file
+rm -f "$SESSIONS_FILE"
+
+# If user cancelled, exit
+if [ -z "$SELECTION" ]; then
+  echo "Cancelled"
+  exit 0
+fi
+
+# Extract session ID (last field after final ·)
+SESSION_ID=$(echo "$SELECTION" | awk -F' · ' '{print $NF}')
+
+echo ""
+echo "Resuming session: $SESSION_ID"
+echo "Selection: $SELECTION"
+echo ""
+
+# Resume the session
+exec claude --resume "$SESSION_ID"
+```
+
+### Step 3: Make it executable and run
+
+```bash
+chmod +x /tmp/resume-claude-session.sh && /tmp/resume-claude-session.sh
+```
+
+## What The User Sees
+
+The picker will display sessions like:
+
+```
+Recent Claude Code Sessions (with labels)
+
+→ Testing plugins in the transplant-gcp · transplant-gcp · 2025-11-17 20:20 · bbace15c-c275-4f21-8501-7796ec5bbe92
+  Netlify MCP integration work · transplant-gcp · 2025-11-11 21:24 · dbff96f6-6782-4c06-aa71-9db466e2ba0b
+  Testing developer-utilities plugin · Code · 2025-11-15 16:31 · fccea55b-62b9-447d-ac21-76c04e32aece
+  what's next?... · transplant-gcp · 2025-11-09 00:58 · ed3b556e-85b4-4e23-95a8-b0353ab3359a
+```
+
+**Features:**
+- ✅ Shows custom labels (if set)
+- ✅ Shows first message (if no label)
+- ✅ Shows project name
+- ✅ Shows last activity date
+- ✅ Fuzzy search (type to filter)
+- ✅ Arrow keys to select
+- ✅ Enter to resume
+
+## Usage
+
+Instead of running `claude --resume`, run:
+
+```
+/resume-session
+```
+
+This will:
+1. Show an interactive picker
+2. Let you search/filter by label or project
+3. Resume the selected session
+
+## Installing fzf
+
+If fzf is not installed:
+
+**Ubuntu/Debian:**
+```bash
+sudo apt install fzf
+```
+
+**macOS:**
+```bash
+brew install fzf
+```
+
+**Other:**
+```bash
+git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
+~/.fzf/install
+```
+
+## Related Commands
+
+- `/list-sessions` - View all sessions (non-interactive)
+- `/label-session` - Add labels to sessions
+- `claude --resume` - Built-in resume (no labels)
+
+## Notes
+
+- Uses `fzf` for interactive selection
+- Labels take priority over first message
+- Shows project name and date for context
+- Directly resumes the selected session
+- Ctrl+C to cancel
+
+## Troubleshooting
+
+**"fzf: command not found"**
+- Install fzf using the instructions above
+
+**"No sessions found"**
+- Check `~/.claude/history.jsonl` exists
+- Ensure you have at least one previous session
+
+**Picker doesn't show labels**
+- Labels are optional
+- Use `/label-session` to add labels to sessions
+- Sessions without labels show their first message instead

--- a/.claude/commands/update-plugins.md
+++ b/.claude/commands/update-plugins.md
@@ -1,0 +1,244 @@
+---
+description: Update all git-based plugins in ~/.claude/plugins/ with one command
+---
+
+## Your Task
+
+Update all git-based Claude Code plugins to their latest versions by running `git pull` in each plugin directory.
+
+**Related:** This addresses GitHub issue [#11676](https://github.com/anthropics/claude-code/issues/11676) - plugin update-all command.
+
+## How This Works
+
+This command loops through all directories in `~/.claude/plugins/` and:
+1. Checks if each directory is a git repository
+2. Runs `git pull` to update it
+3. Reports success or errors for each plugin
+4. Shows summary of results
+
+**Note:** This only works for plugins installed via git (cloned repositories). Plugins installed via other methods will be skipped.
+
+## Update Process
+
+### Step 1: Check if Plugins Directory Exists
+
+```bash
+echo "=== Checking for Plugins ===" && echo ""
+```
+
+```bash
+if [ -d ~/.claude/plugins ]; then echo "✓ Plugins directory found (~/.claude/plugins/)"; else echo "✗ No plugins directory found" && echo "Nothing to update."; fi
+```
+
+### Step 2: List All Installed Plugins
+
+```bash
+echo "" && echo "=== Installed Plugins ===" && echo ""
+```
+
+```bash
+ls -1 ~/.claude/plugins/ 2>/dev/null | grep -v "^config.json$" || echo "No plugins found"
+```
+
+### Step 3: Identify Git-Based Plugins
+
+```bash
+echo "" && echo "=== Git-Based Plugins (Updatable) ===" && echo ""
+```
+
+```bash
+for plugin in ~/.claude/plugins/*/; do if [ -d "$plugin/.git" ]; then basename "$plugin"; fi; done 2>/dev/null || echo "No git-based plugins found"
+```
+
+**If no git-based plugins found, stop here. Otherwise continue:**
+
+### Step 4: Update Each Plugin
+
+**Ask user for confirmation before proceeding:**
+
+Before updating plugins, ask: **"Ready to update all git-based plugins? This will run `git pull` in each plugin directory."**
+
+Wait for user confirmation. If yes, proceed:
+
+```bash
+echo "" && echo "=== Updating Plugins ===" && echo ""
+```
+
+For each git-based plugin, run updates:
+
+```bash
+cd ~/.claude/plugins && for plugin in */; do if [ -d "$plugin/.git" ]; then echo "" && echo "Updating: $plugin" && cd "$plugin" && git pull && cd .. || echo "Error updating $plugin"; fi; done && echo "" && echo "=== Update Complete ==="
+```
+
+### Step 5: Show Summary
+
+After updates complete, show summary:
+
+```bash
+echo "" && echo "=== Summary ===" && echo ""
+```
+
+```bash
+echo "Updated plugins are ready to use after restarting Claude Code."
+```
+
+```bash
+echo "" && echo "To verify updates, check git status in each plugin:" && echo "  cd ~/.claude/plugins/plugin-name && git log -1"
+```
+
+## Expected Output
+
+**Successful update example:**
+```
+=== Updating Plugins ===
+
+Updating: developer-utilities/
+Already up to date.
+
+Updating: commit-commands/
+Updating 5348233..a1b2c3d
+Fast-forward
+ commands/new-command.md | 50 ++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 50 insertions(+)
+
+Updating: feature-dev/
+Already up to date.
+
+=== Update Complete ===
+
+=== Summary ===
+Updated plugins are ready to use after restarting Claude Code.
+```
+
+**Error example:**
+```
+Updating: my-custom-plugin/
+error: Your local changes to the following files would be overwritten by merge:
+	commands/example.md
+Please commit your changes or stash them before you merge.
+Aborting
+Error updating my-custom-plugin/
+```
+
+## Handling Errors
+
+**Common errors and solutions:**
+
+### 1. Merge Conflicts
+```
+error: Your local changes would be overwritten by merge
+```
+**Fix:** Manually resolve in that plugin directory:
+```bash
+cd ~/.claude/plugins/plugin-name
+git status
+git stash  # Save local changes
+git pull
+git stash pop  # Restore local changes
+```
+
+### 2. Authentication Required
+```
+fatal: Authentication failed
+```
+**Fix:** Set up git credentials or SSH keys for the remote repository.
+
+### 3. Diverged Branches
+```
+Your branch and 'origin/main' have diverged
+```
+**Fix:** Manually resolve in that plugin directory:
+```bash
+cd ~/.claude/plugins/plugin-name
+git status
+git pull --rebase  # Or merge manually
+```
+
+### 4. Not a Git Repository
+```
+(Plugin is skipped silently)
+```
+**This is normal** - only git-based plugins are updated.
+
+## What Gets Updated
+
+**This command updates:**
+- ✅ Official Anthropic plugins (cloned from anthropics/claude-code)
+- ✅ Third-party plugins (cloned from any GitHub repo)
+- ✅ Your own plugins (cloned from your repos)
+- ✅ Forked plugins (cloned from your fork)
+
+**This command does NOT update:**
+- ❌ Plugins installed via marketplace (different update mechanism)
+- ❌ Plugins that are just copied files (no .git directory)
+- ❌ Symlinked plugins (updates happen in source directory)
+
+## Best Practices
+
+1. **Commit local changes first** - If you've modified any plugins locally, commit or stash changes before updating
+2. **Run regularly** - Update plugins weekly or monthly to get latest features and fixes
+3. **Check changelogs** - After updating, review what changed in each plugin
+4. **Test after updating** - Restart Claude Code and verify plugins still work
+5. **Backup important customizations** - If you've customized plugins, back up your changes
+
+## Updating Individual Plugins
+
+To update just one plugin manually:
+
+```bash
+cd ~/.claude/plugins/plugin-name
+git pull
+```
+
+## Project Plugins
+
+This command only updates global plugins in `~/.claude/plugins/`.
+
+To update project-specific plugins in `.claude/plugins/`, run the same commands but change the path:
+
+```bash
+cd .claude/plugins && for plugin in */; do if [ -d "$plugin/.git" ]; then echo "Updating: $plugin" && cd "$plugin" && git pull && cd ..; fi; done
+```
+
+## After Updating
+
+**Important:** Restart Claude Code for plugin updates to take effect.
+
+Plugins are loaded when Claude Code starts, so updates won't be active until you restart your session.
+
+## Troubleshooting
+
+### Updates don't take effect
+- **Solution:** Restart Claude Code completely (exit all sessions)
+
+### Plugin broken after update
+- **Solution:** Roll back to previous version:
+```bash
+cd ~/.claude/plugins/plugin-name
+git log  # Find previous commit hash
+git reset --hard <commit-hash>
+```
+
+### Want to prevent a plugin from updating
+- **Solution:** Remove the git remote:
+```bash
+cd ~/.claude/plugins/plugin-name
+git remote remove origin
+```
+Now it won't update (no remote to pull from)
+
+## Documentation References
+
+- [Official Plugins Documentation](https://docs.claude.com/en/docs/claude-code/plugins)
+- [GitHub Issue #11676](https://github.com/anthropics/claude-code/issues/11676) - Plugin update-all request
+- [Git Documentation](https://git-scm.com/docs/git-pull)
+
+## Future Enhancements
+
+This command currently handles git-based plugins. In the future, Claude Code may support:
+- Marketplace-based plugin updates
+- Version pinning
+- Automatic update checks
+- Rollback functionality
+
+For now, this command provides a convenient way to update git-cloned plugins with one command instead of updating each manually.

--- a/.claude/commands/validate-commands.md
+++ b/.claude/commands/validate-commands.md
@@ -1,0 +1,176 @@
+---
+description: Validate slash command files, check for errors, and verify they will work after restart
+---
+
+## What This Command Does
+
+This command helps you develop and debug slash commands by:
+- Validating command file structure
+- Checking for common syntax errors
+- Listing all available commands
+- Showing which commands will work after restart
+
+**Note on Command Reloading:**
+This command cannot actually reload commands into the current session - that requires changes to the Claude Code CLI itself. See GitHub issue [#11632](https://github.com/anthropics/claude-code/issues/11632).
+
+After validating your commands, you must restart Claude Code for changes to take effect.
+
+## Validation Steps
+
+### Step 1: List Available Commands
+
+Show project commands:
+
+```bash
+find .claude/commands/ -name "*.md" -type f 2>/dev/null | sed 's|.claude/commands/||' | sed 's|.md$||' | sed 's|^|/|' | sort || echo "No project commands found"
+```
+
+Show global commands:
+
+```bash
+find ~/.claude/commands/ -name "*.md" -type f 2>/dev/null | sed 's|.*/||' | sed 's|.md$||' | sed 's|^|/|' | sort || echo "No global commands found"
+```
+
+## Step 2: Validate Command Files
+
+Check for commands with invalid frontmatter:
+
+```bash
+find .claude/commands/ -name "*.md" -type f 2>/dev/null -exec sh -c 'file="{}"; if ! head -1 "$file" | grep -q "^---$"; then echo "❌ Missing frontmatter: $file"; fi' \;
+```
+
+```bash
+find ~/.claude/commands/ -name "*.md" -type f 2>/dev/null -exec sh -c 'file="{}"; if ! head -1 "$file" | grep -q "^---$"; then echo "❌ Missing frontmatter: $file"; fi' \;
+```
+
+Check for commands missing description:
+
+```bash
+find .claude/commands/ -name "*.md" -type f 2>/dev/null -exec sh -c 'file="{}"; if ! head -10 "$file" | grep -q "description:"; then echo "⚠️  No description: $file"; fi' \;
+```
+
+```bash
+find ~/.claude/commands/ -name "*.md" -type f 2>/dev/null -exec sh -c 'file="{}"; if ! head -10 "$file" | grep -q "description:"; then echo "⚠️  No description: $file"; fi' \;
+```
+
+## Step 3: Show Command Details
+
+Count total commands:
+
+```bash
+echo "Total project commands: $(find .claude/commands/ -name "*.md" -type f 2>/dev/null | wc -l)"
+```
+
+```bash
+echo "Total global commands: $(find ~/.claude/commands/ -name "*.md" -type f 2>/dev/null | wc -l)"
+```
+
+Show recently modified commands (last 7 days):
+
+```bash
+find .claude/commands/ -name "*.md" -type f -mtime -7 2>/dev/null | sed 's|.claude/commands/||' | sed 's|.md$||' | sed 's|^|Recently modified: /|' || echo "No recently modified project commands"
+```
+
+```bash
+find ~/.claude/commands/ -name "*.md" -type f -mtime -7 2>/dev/null | sed 's|.*/||' | sed 's|.md$||' | sed 's|^|Recently modified: /|' || echo "No recently modified global commands"
+```
+
+## Step 4: Inspect Specific Command (Ask User)
+
+**If the user wants to inspect a specific command, ask them which one, then:**
+
+```bash
+cat .claude/commands/COMMAND-NAME.md | head -20
+```
+
+Or for global:
+
+```bash
+cat ~/.claude/commands/COMMAND-NAME.md | head -20
+```
+
+## Step 5: Check Permissions
+
+Verify command directories are readable:
+
+```bash
+ls -ld .claude/commands/ 2>/dev/null || echo "No project commands directory"
+```
+
+```bash
+ls -ld ~/.claude/commands/ 2>/dev/null || echo "No global commands directory"
+```
+
+## Step 6: Restart Instructions
+
+**To make new/modified commands available, you must restart Claude Code:**
+
+**Fastest restart method:**
+1. Type `exit` or press Ctrl+D in Claude Code
+2. Run `claude` again in the same directory
+3. Your commands will be loaded
+
+**Alternative:**
+- Close the terminal/IDE tab running Claude Code
+- Open a new session
+
+**Note:** There is currently no way to hot-reload commands without restarting. This is a limitation of the CLI that may be addressed in a future update.
+
+## Common Issues
+
+### Command Not Showing Up After Restart
+
+1. **Check filename** - Must be `*.md` in `.claude/commands/` or `~/.claude/commands/`
+2. **Check frontmatter** - Must start with `---` and include `description:`
+3. **Check permissions** - File must be readable (644 or similar)
+4. **Check syntax** - Use this command to validate before restarting
+
+### Command Shows But Doesn't Work
+
+1. **Check bash syntax** - Multi-line if/for/while statements don't work
+2. **Use single-line commands** - Chain with `&&` or `;` if needed
+3. **Test commands individually** - Run the bash blocks manually first
+
+## Command File Template
+
+Here's a valid command structure:
+
+```markdown
+---
+description: Brief description of what this command does
+---
+
+## Your Task
+
+Clear instructions for what Claude should do when this command runs.
+
+## Commands to Execute
+
+### Step 1: First Action
+
+```\`bash
+echo "Single-line commands work best"
+```\`
+
+### Step 2: Next Action
+
+```\`bash
+ls -la | grep .md
+```\`
+
+## Expected Behavior
+
+Describe what should happen after running this command.
+```
+
+## Expected Behavior
+
+After running this command, you will:
+
+1. ✓ See all available commands (project and global)
+2. ✓ Know which commands have validation issues
+3. ✓ See recently modified commands
+4. ✓ Get restart instructions
+5. ✗ Commands will **NOT** be reloaded (requires restart)
+
+**This command validates and prepares for restart - it does not actually reload commands.**

--- a/services/missed-dose/services/agents/response_parser.py
+++ b/services/missed-dose/services/agents/response_parser.py
@@ -1,0 +1,115 @@
+"""
+Shared JSON parsing utilities for ADK agent responses.
+
+All agents receive AI responses that contain JSON. This module provides
+standardized parsing logic to extract structured data from those responses.
+"""
+
+import json
+from typing import Any
+
+
+def _try_parse_json_dict(text: str) -> dict[str, Any] | None:
+    """Try to parse text as JSON dict, return None if fails."""
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed
+    except json.JSONDecodeError:
+        pass
+    return None
+
+
+def _extract_code_block(text: str, marker: str) -> str | None:
+    """Extract content between marker and closing ```."""
+    start = text.find(marker)
+    if start == -1:
+        return None
+
+    content_start = start + len(marker)
+    # Skip whitespace
+    while content_start < len(text) and text[content_start].isspace():
+        content_start += 1
+
+    # Find closing ```
+    content_end = text.find("```", content_start)
+    if content_end == -1:
+        return None
+
+    return text[content_start:content_end]
+
+
+def _find_json_object(text: str) -> str | None:
+    """Find first complete JSON object by counting braces."""
+    brace_index = text.find("{")
+    if brace_index == -1:
+        return None
+
+    depth = 0
+    in_string = False
+    escape_next = False
+
+    for i in range(brace_index, len(text)):
+        char = text[i]
+
+        if escape_next:
+            escape_next = False
+            continue
+
+        if char == "\\":
+            escape_next = True
+            continue
+
+        if char == '"':
+            in_string = not in_string
+            continue
+
+        if not in_string:
+            if char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return text[brace_index : i + 1]
+
+    return None
+
+
+def extract_json_from_response(response_text: str) -> dict[str, Any] | None:
+    """
+    Extract and parse JSON from an AI response.
+
+    The AI may wrap JSON in markdown code blocks or return it raw.
+    This function tries multiple extraction patterns.
+
+    Args:
+        response_text: Raw text response from the AI
+
+    Returns:
+        Parsed JSON dict if successful, None if parsing fails
+    """
+    if not response_text:
+        return None
+
+    # Try ```json ... ``` code block
+    content = _extract_code_block(response_text, "```json")
+    if content:
+        result = _try_parse_json_dict(content)
+        if result:
+            return result
+
+    # Try ``` ... ``` code block
+    content = _extract_code_block(response_text, "```")
+    if content:
+        result = _try_parse_json_dict(content)
+        if result:
+            return result
+
+    # Try raw JSON object
+    content = _find_json_object(response_text)
+    if content:
+        result = _try_parse_json_dict(content)
+        if result:
+            return result
+
+    return None

--- a/services/missed-dose/services/data/srtr_outcomes.py
+++ b/services/missed-dose/services/data/srtr_outcomes.py
@@ -1,0 +1,203 @@
+"""
+SRTR Outcomes Data Query Module
+
+Provides easy access to real transplant outcomes data from SRTR for use by ADK agents.
+Data is loaded from JSON files (fast, no Firestore queries needed).
+Supports all 6 organ types: kidney, liver, heart, lung, pancreas, intestine.
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class SRTROutcomesData:
+    """Query SRTR transplant outcomes data for any organ."""
+
+    SUPPORTED_ORGANS = ["kidney", "liver", "heart", "lung", "pancreas", "intestine"]
+
+    def __init__(self, organ: str = "kidney", data_dir: str = "data/srtr/processed"):
+        """
+        Initialize SRTR data accessor.
+
+        Args:
+            organ: Organ type (kidney, liver, heart, lung, pancreas, intestine)
+            data_dir: Directory containing processed JSON files
+        """
+        if organ.lower() not in self.SUPPORTED_ORGANS:
+            raise ValueError(f"Unsupported organ: {organ}. Must be one of {self.SUPPORTED_ORGANS}")
+
+        self.organ = organ.lower()
+        self.data_dir = Path(data_dir)
+        self._data: list[dict[str, Any]] | None = None
+        self._summary: dict[str, Any] | None = None
+        self._load_data()
+
+    def _load_data(self):
+        """Load data from JSON files for specified organ."""
+        flat_file = self.data_dir / f"{self.organ}_outcomes_flat.json"
+        summary_file = self.data_dir / f"{self.organ}_summary.json"
+
+        if flat_file.exists():
+            with open(flat_file) as f:
+                self._data = json.load(f)
+
+        if summary_file.exists():
+            with open(summary_file) as f:
+                self._summary = json.load(f)
+
+    def get_acute_rejection_rate(self, age_group: str | None = None) -> float | dict[str, float]:
+        """
+        Get acute rejection rate (latest year: 2022).
+
+        Args:
+            age_group: Age group ("18-34 years", "35-49", "50-64", "65+")
+                      If None, returns all age groups
+
+        Returns:
+            Rejection rate percentage, or dict of all rates
+        """
+        if not self._summary:
+            return 0.0
+
+        rates: dict[str, float] = self._summary.get("latest_acute_rejection_rates", {})
+
+        if age_group:
+            return float(rates.get(age_group, 0.0))
+
+        return rates
+
+    def get_graft_survival_rate(
+        self, months_post_transplant: int, age_group: str | None = None
+    ) -> float:
+        """
+        Get graft survival rate at specified time post-transplant.
+
+        Args:
+            months_post_transplant: Months after transplant (e.g., 6, 12, 24)
+            age_group: Age group to filter by
+
+        Returns:
+            Survival rate percentage
+        """
+        if not self._data:
+            return 99.0  # Conservative default
+
+        years = months_post_transplant / 12.0
+
+        # Find matching records
+        matches = [
+            r
+            for r in self._data
+            if r.get("metric") == "graft_survival"
+            and abs(r.get("years_post_transplant", 0) - years) < 0.1
+        ]
+
+        if age_group:
+            matches = [r for r in matches if r.get("age_group") == age_group]
+
+        if not matches:
+            # Return 1-year average if no exact match
+            if age_group and self._summary:
+                avg_survival: dict[str, float] = self._summary.get("average_graft_survival_1yr", {})
+                return float(avg_survival.get(age_group, 98.0))
+            return 98.0
+
+        # Average the matching records
+        survival_rates: list[float] = [float(r["survival_rate"]) for r in matches]
+        return float(sum(survival_rates) / len(survival_rates))
+
+    def get_population_context(self, age_group: str, months_post_transplant: int) -> dict[str, Any]:
+        """
+        Get comprehensive population context for risk assessment.
+
+        Args:
+            age_group: Patient age group
+            months_post_transplant: Months since transplant
+
+        Returns:
+            Dictionary with population statistics
+        """
+        return {
+            "age_group": age_group,
+            "months_post_transplant": months_post_transplant,
+            "baseline_rejection_rate": self.get_acute_rejection_rate(age_group),
+            "expected_graft_survival": self.get_graft_survival_rate(
+                months_post_transplant, age_group
+            ),
+            "data_source": "SRTR 2023 Annual Data Report",
+            "population_size": (self._summary.get("total_records", 0) if self._summary else 0),
+        }
+
+    def format_for_prompt(self, age_group: str, months_post_transplant: int) -> str:
+        """
+        Format population data for inclusion in AI prompt.
+
+        Args:
+            age_group: Patient age group
+            months_post_transplant: Months since transplant
+
+        Returns:
+            Formatted string for prompt context
+        """
+        context = self.get_population_context(age_group, months_post_transplant)
+
+        return f"""Population Statistics (SRTR 2023 - {self.organ.capitalize()} Transplant):
+- Organ: {self.organ.capitalize()}
+- Age Group: {context["age_group"]}
+- Time Post-Transplant: {context["months_post_transplant"]} months
+- Baseline Acute Rejection Rate: {context["baseline_rejection_rate"]:.2f}%
+- Expected Graft Survival: {context["expected_graft_survival"]:.2f}%
+- Data Source: {context["data_source"]}"""
+
+    def get_risk_multiplier(self, hours_late: float, age_group: str) -> tuple[float, str]:
+        """
+        Calculate risk multiplier based on population data and missed dose severity.
+
+        Args:
+            hours_late: Hours medication is late
+            age_group: Patient age group
+
+        Returns:
+            Tuple of (risk_multiplier, explanation)
+        """
+        # Get baseline rejection rate for age group
+        baseline_rejection = self.get_acute_rejection_rate(age_group)
+
+        # Risk factors
+        if hours_late > 12:
+            multiplier = 1.5
+            explanation = f"Dose >12h late significantly increases risk. Your age group ({age_group}) has baseline rejection rate of {baseline_rejection:.2f}%."
+        elif hours_late > 6:
+            multiplier = 1.2
+            explanation = f"Dose 6-12h late moderately increases risk. Baseline rejection rate for {age_group}: {baseline_rejection:.2f}%."
+        elif hours_late > 2:
+            multiplier = 1.1
+            explanation = f"Slight risk increase. Stay vigilant. Baseline rejection rate: {baseline_rejection:.2f}%."
+        else:
+            multiplier = 1.0
+            explanation = (
+                f"Minimal risk impact. Baseline rejection rate: {baseline_rejection:.2f}%."
+            )
+
+        return multiplier, explanation
+
+
+# Global instances for easy import (one per organ)
+_srtr_data_cache: dict[str, SRTROutcomesData] = {}
+
+
+def get_srtr_data(organ: str = "kidney") -> SRTROutcomesData:
+    """
+    Get cached instance of SRTR data for specified organ.
+
+    Args:
+        organ: Organ type (kidney, liver, heart, lung, pancreas, intestine)
+
+    Returns:
+        SRTROutcomesData instance for the specified organ
+    """
+    organ_lower = organ.lower()
+    if organ_lower not in _srtr_data_cache:
+        _srtr_data_cache[organ_lower] = SRTROutcomesData(organ=organ_lower)
+    return _srtr_data_cache[organ_lower]

--- a/test_adk_api.py
+++ b/test_adk_api.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""
+Quick test script for ADK-integrated REST API
+Tests that the Flask app can start and respond to requests
+"""
+
+import os
+import sys
+
+# Set up test environment
+os.environ["GOOGLE_CLOUD_PROJECT"] = "transplant-prediction-test"
+
+# Mock Firestore to avoid requiring credentials
+sys.modules["google.cloud.firestore"] = type(sys)("mock_firestore")
+
+
+class MockFirestoreClient:
+    def __init__(self, project=None):
+        self.project = project
+
+    def collection(self, name):  # noqa: ARG002 — mock signature must match Firestore client
+        return MockCollection()
+
+
+class MockCollection:
+    def document(self, doc_id=None):  # noqa: ARG002 — mock signature must match Firestore client
+        return MockDocument()
+
+
+class MockDocument:
+    def get(self):
+        return MockDocSnapshot()
+
+    def set(self, data):
+        pass
+
+
+class MockDocSnapshot:
+    exists = True
+
+    def to_dict(self):
+        return {
+            "transplant_type": "kidney",
+            "months_post_transplant": 6,
+            "medications": ["tacrolimus", "mycophenolate"],
+            "adherence_rate": 0.85,
+        }
+
+
+sys.modules["google.cloud.firestore"].Client = MockFirestoreClient  # type: ignore[attr-defined]
+
+
+def test_health_endpoint():
+    """Test that the /health endpoint works"""
+    # Import after mocking Firestore
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "services"))
+    sys.path.insert(
+        0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "services", "missed-dose")
+    )
+
+    # Import main module directly
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("main", "services/missed-dose/main.py")
+    main_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(main_module)
+    app = main_module.app
+
+    with app.test_client() as client:
+        response = client.get("/health")
+        print("✓ Health endpoint test:")
+        print(f"  Status: {response.status_code}")
+        print(f"  Response: {response.get_json()}")
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "healthy"
+        assert data["ai_system"] == "Google ADK Multi-Agent System"
+        assert "MedicationAdvisor" in data["agents"]["specialists"]
+        print("  ✓ All assertions passed\n")
+
+
+def test_root_endpoint():
+    """Test that the root endpoint works"""
+    # Import main module directly
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("main", "services/missed-dose/main.py")
+    main_module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(main_module)
+    app = main_module.app
+
+    with app.test_client() as client:
+        response = client.get("/")
+        print("✓ Root endpoint test:")
+        print(f"  Status: {response.status_code}")
+        print(f"  Response: {response.get_json()}")
+        assert response.status_code == 200
+        print("  ✓ All assertions passed\n")
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Testing ADK-Integrated REST API")
+    print("=" * 60 + "\n")
+
+    try:
+        test_health_endpoint()
+        test_root_endpoint()
+        print("=" * 60)
+        print("✓ All tests passed!")
+        print("=" * 60)
+    except Exception as e:
+        print(f"\n✗ Test failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary
Recover three threads from a stash created 2026-05-10 (before the `~/Code/` secret-sprawl audit fanout).

### 1. `.claude/commands/` — 9 Claude Code slash commands
`clean`, `diagnose-skills`, `init-skills`, `label-session`, `list-sessions`, `permission-examples`, `resume-session`, `update-plugins`, `validate-commands`

Top-level duplicates at `.claude/X.md` were stale (migration leftovers) and removed.

### 2. `services/missed-dose/services/{agents,data}/` — self-contained imports
- `response_parser.py` (byte-identical copy of `services/agents/response_parser.py`)
- `srtr_outcomes.py` (byte-identical copy of `services/data/srtr_outcomes.py`)

Needed so the `missed-dose` service can deploy standalone (own Dockerfile, own Cloud Run image) without runtime dependency on the parent repo tree.

**TODO** (separate ticket): refactor to copy these at Docker build time rather than maintaining duplicates in source.

### 3. `test_adk_api.py` — root-level smoke test
ADK-integrated REST API smoke test with mocked Firestore. Added:
- `# type: ignore[attr-defined]` on the dynamic `sys.modules` monkey-patch (mypy can't statically check this pattern)
- `# noqa: ARG002` on mock methods where args are required by the Firestore client interface but unused in the mock

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, bandit, gitleaks, etc.)
- [ ] `pytest test_adk_api.py` runs locally and passes
- [ ] Slash commands work in Claude Code after merge (`/clean`, `/diagnose-skills`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)