### PR TITLE
test: achieve 100% code coverage

### DIFF
--- a/tests/unit/agents/test_base_adk_agent.py
+++ b/tests/unit/agents/test_base_adk_agent.py
@@ -1,0 +1,61 @@
+"""Unit tests for BaseADKAgent — covers session-creation branch and default parse."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestBaseADKAgentInvokeSessionCreation:
+    @patch("services.agents.base_adk_agent.Runner")
+    @patch("services.agents.base_adk_agent.Agent")
+    @patch("services.agents.base_adk_agent.types")
+    def test_invoke_agent_creates_session_when_none(self, mock_types, mock_agent, mock_runner_cls):
+        from services.agents.base_adk_agent import BaseADKAgent
+
+        mock_runner = MagicMock()
+        mock_runner_cls.return_value = mock_runner
+        mock_runner.app_name = "test"
+
+        mock_session_svc = AsyncMock()
+        mock_session_svc.get_session.return_value = None
+        mock_runner.session_service = mock_session_svc
+
+        async def _gen():
+            event = MagicMock()
+            event.content.parts = [MagicMock(text="hello")]
+            yield event
+
+        mock_runner.run_async.return_value = _gen()
+
+        agent = BaseADKAgent(
+            agent_config={"name": "T", "model": "m", "description": "d", "instruction": "i"},
+            app_name="test",
+            session_id_prefix="pfx",
+            api_key="k",
+        )
+
+        result = agent._invoke_agent("prompt")
+
+        assert result == "hello"
+        mock_session_svc.create_session.assert_called_once()
+
+
+class TestBaseADKAgentDefaultParse:
+    @patch("services.agents.base_adk_agent.Runner")
+    @patch("services.agents.base_adk_agent.Agent")
+    @patch("services.agents.base_adk_agent.types")
+    def test_default_parse_agent_response(self, mock_types, mock_agent_cls, mock_runner_cls):
+        from services.agents.base_adk_agent import BaseADKAgent
+
+        mock_agent_inst = MagicMock()
+        mock_agent_inst.name = "TestAgent"
+        mock_agent_cls.return_value = mock_agent_inst
+
+        agent = BaseADKAgent(
+            agent_config={"name": "T", "model": "m", "description": "d", "instruction": "i"},
+            app_name="test",
+            session_id_prefix="pfx",
+        )
+
+        result = agent._parse_agent_response("raw text")
+
+        assert result["agent_name"] == "TestAgent"
+        assert result["raw_response"] == "raw text"

--- a/tests/unit/agents/test_coordinator_coverage.py
+++ b/tests/unit/agents/test_coordinator_coverage.py
@@ -1,0 +1,194 @@
+"""Coverage tests for TransplantCoordinatorAgent — sequential consult, parallel consult,
+session-creation branches, classify general_inquiry, and _synthesize_response."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+def _async_generator_mock(text: str):
+    async def _generator():
+        event = MagicMock()
+        event.content = MagicMock()
+        event.content.parts = [MagicMock()]
+        event.content.parts[0].text = text
+        yield event
+
+    return _generator()
+
+
+class TestSessionCreationBranch:
+    @patch("services.agents.coordinator_agent.Runner")
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_analyze_routing_creates_session_when_none(
+        self, mock_types, mock_agent_class, mock_runner_class
+    ):
+        mock_runner = MagicMock()
+        mock_runner_class.return_value = mock_runner
+        mock_runner.app_name = "TransplantCoordinator"
+
+        mock_session_svc = AsyncMock()
+        mock_session_svc.get_session.return_value = None
+        mock_runner.session_service = mock_session_svc
+        mock_runner.run_async.side_effect = lambda **_: _async_generator_mock("Routing")
+
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(api_key="test")
+        agent._analyze_routing("I missed my dose")
+
+        mock_session_svc.create_session.assert_called()
+
+
+class TestClassifyGeneralInquiry:
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_classify_empty_list(self, mock_types, mock_agent_class):
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(api_key="test")
+        assert agent._classify_request_type([]) == "general_inquiry"
+
+
+class TestDefaultRouting:
+    @patch("services.agents.coordinator_agent.Runner")
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_defaults_to_medication_advisor_for_unclear_request(
+        self, mock_types, mock_agent_class, mock_runner_class
+    ):
+        mock_runner = MagicMock()
+        mock_runner_class.return_value = mock_runner
+        mock_runner.app_name = "TransplantCoordinator"
+
+        mock_session_svc = AsyncMock()
+        mock_session_svc.get_session.return_value = MagicMock()
+        mock_runner.session_service = mock_session_svc
+        mock_runner.run_async.side_effect = lambda **_: _async_generator_mock("Routing")
+
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(api_key="test")
+        routing = agent._analyze_routing("hello there")
+
+        assert "MedicationAdvisor" in routing["agents_needed"]
+
+
+class TestSequentialConsult:
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_consult_all_specialists_sequential(self, mock_types, mock_agent_class):
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(
+            api_key="test",
+            medication_advisor=MagicMock(),
+            symptom_monitor=MagicMock(),
+            drug_interaction_checker=MagicMock(),
+        )
+
+        routing = {
+            "agents_needed": ["MedicationAdvisor", "SymptomMonitor", "DrugInteractionChecker"]
+        }
+        responses = agent._consult_specialists(
+            routing_decision=routing,
+            _request="test",
+            _patient_id=None,
+            _patient_context=None,
+            parallel=False,
+        )
+
+        assert "MedicationAdvisor" in responses
+        assert "SymptomMonitor" in responses
+        assert "DrugInteractionChecker" in responses
+        assert responses["MedicationAdvisor"]["status"] == "success"
+        assert responses["SymptomMonitor"]["status"] == "success"
+        assert responses["DrugInteractionChecker"]["status"] == "success"
+
+
+class TestParallelConsult:
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_consult_specialists_parallel(self, mock_types, mock_agent_class):
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(
+            api_key="test",
+            medication_advisor=MagicMock(),
+            symptom_monitor=MagicMock(),
+            drug_interaction_checker=MagicMock(),
+        )
+
+        result = asyncio.run(
+            agent._consult_specialists_parallel(
+                ["MedicationAdvisor", "SymptomMonitor", "DrugInteractionChecker"]
+            )
+        )
+
+        assert "MedicationAdvisor" in result
+        assert "SymptomMonitor" in result
+        assert "DrugInteractionChecker" in result
+
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_async_medication_advisor(self, mock_types, mock_agent_class):
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(api_key="test", medication_advisor=MagicMock())
+        result = asyncio.run(agent._consult_medication_advisor_async())
+        assert result["agent"] == "MedicationAdvisor"
+
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_async_symptom_monitor(self, mock_types, mock_agent_class):
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(api_key="test", symptom_monitor=MagicMock())
+        result = asyncio.run(agent._consult_symptom_monitor_async())
+        assert result["agent"] == "SymptomMonitor"
+
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_async_drug_interaction(self, mock_types, mock_agent_class):
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(api_key="test", drug_interaction_checker=MagicMock())
+        result = asyncio.run(agent._consult_drug_interaction_async())
+        assert result["agent"] == "DrugInteractionChecker"
+
+
+class TestSynthesizeResponse:
+    @patch("services.agents.coordinator_agent.Runner")
+    @patch("services.agents.coordinator_agent.Agent")
+    @patch("services.agents.coordinator_agent.types")
+    def test_synthesize_with_specialist_responses(
+        self, mock_types, mock_agent_class, mock_runner_class
+    ):
+        mock_runner = MagicMock()
+        mock_runner_class.return_value = mock_runner
+        mock_runner.app_name = "TransplantCoordinator"
+
+        mock_session_svc = AsyncMock()
+        mock_session_svc.get_session.return_value = None
+        mock_runner.session_service = mock_session_svc
+        mock_runner.run_async.side_effect = lambda **_: _async_generator_mock("Synthesized")
+
+        from services.agents.coordinator_agent import TransplantCoordinatorAgent
+
+        agent = TransplantCoordinatorAgent(api_key="test")
+        result = agent._synthesize_response(
+            request="I missed my dose",
+            routing_decision={"reasoning": "test reason", "request_type": "missed_dose"},
+            specialist_responses={
+                "MedicationAdvisor": {
+                    "response": "Take dose now",
+                    "status": "success",
+                }
+            },
+        )
+
+        assert "agents_consulted" in result
+        assert "MedicationAdvisor" in result["agents_consulted"]
+        assert result["request_type"] == "missed_dose"
+        assert result["confidence"] == 0.85
+        mock_session_svc.create_session.assert_called()

--- a/tests/unit/agents/test_response_parser_edges.py
+++ b/tests/unit/agents/test_response_parser_edges.py
@@ -1,0 +1,40 @@
+"""Edge-case tests for response_parser — covers unclosed code blocks and incomplete JSON."""
+
+from services.agents.response_parser import extract_json_from_response
+
+
+class TestExtractCodeBlockEdges:
+    def test_unclosed_code_block_falls_through_to_raw_json(self):
+        response = '```json\n{"key": "value"}'
+        result = extract_json_from_response(response)
+        assert result is not None
+        assert result["key"] == "value"
+
+    def test_unclosed_plain_code_block_falls_through_to_raw_json(self):
+        response = '```\n{"key": "value"}'
+        result = extract_json_from_response(response)
+        assert result is not None
+        assert result["key"] == "value"
+
+
+class TestFindJsonObjectEdges:
+    def test_incomplete_json_braces(self):
+        response = '{"key": "value"'
+        result = extract_json_from_response(response)
+        assert result is None
+
+    def test_json_with_escaped_quotes(self):
+        response = r'{"msg": "she said \"hello\""}'
+        result = extract_json_from_response(response)
+        assert result is not None
+        assert result["msg"] == 'she said "hello"'
+
+    def test_json_with_backslash_not_before_quote(self):
+        response = r'{"path": "C:\\Users\\test"}'
+        result = extract_json_from_response(response)
+        assert result is not None
+
+    def test_no_braces_at_all(self):
+        response = "Just plain text with no JSON"
+        result = extract_json_from_response(response)
+        assert result is None

--- a/tests/unit/agents/test_srtr_exception_paths.py
+++ b/tests/unit/agents/test_srtr_exception_paths.py
@@ -1,0 +1,43 @@
+"""Tests for SRTR exception handling in medication_advisor and rejection_risk agents."""
+
+from unittest.mock import patch
+
+
+class TestMedicationAdvisorSRTRException:
+    @patch("services.agents.medication_advisor_agent.get_srtr_data")
+    @patch("services.agents.base_adk_agent.Agent")
+    @patch("services.agents.base_adk_agent.types")
+    def test_build_prompt_handles_srtr_exception(self, mock_types, mock_agent, mock_get_srtr):
+        mock_get_srtr.side_effect = Exception("SRTR unavailable")
+
+        from services.agents.medication_advisor_agent import MedicationAdvisorAgent
+
+        agent = MedicationAdvisorAgent(api_key="test")
+        prompt = agent._build_missed_dose_prompt(
+            medication="tacrolimus",
+            scheduled_time="08:00",
+            current_time="12:00",
+            patient_id=None,
+            patient_context={"organ_type": "kidney"},
+        )
+
+        assert "WARNING: SRTR data unavailable" in prompt
+
+
+class TestRejectionRiskSRTRException:
+    @patch("services.agents.rejection_risk_agent.get_srtr_data")
+    @patch("services.agents.base_adk_agent.Agent")
+    @patch("services.agents.base_adk_agent.types")
+    def test_build_prompt_handles_srtr_exception(self, mock_types, mock_agent, mock_get_srtr):
+        mock_get_srtr.side_effect = Exception("SRTR unavailable")
+
+        from services.agents.rejection_risk_agent import RejectionRiskAgent
+
+        agent = RejectionRiskAgent(api_key="test")
+        prompt = agent._build_rejection_prompt(
+            symptoms={"fever": 101.0},
+            patient_id=None,
+            patient_context={"organ_type": "kidney"},
+        )
+
+        assert "WARNING: SRTR data unavailable" in prompt

--- a/tests/unit/data/test_srtr_graft_survival.py
+++ b/tests/unit/data/test_srtr_graft_survival.py
@@ -1,0 +1,97 @@
+"""Tests for SRTROutcomesData.get_graft_survival_rate with matching data."""
+
+import json
+import tempfile
+from pathlib import Path
+
+from services.data.srtr_outcomes import SRTROutcomesData
+
+
+class TestGraftSurvivalWithData:
+    def test_returns_average_of_matching_records(self):
+        data = [
+            {
+                "metric": "graft_survival",
+                "years_post_transplant": 1.0,
+                "survival_rate": 95.0,
+                "age_group": "35-49",
+            },
+            {
+                "metric": "graft_survival",
+                "years_post_transplant": 1.0,
+                "survival_rate": 97.0,
+                "age_group": "35-49",
+            },
+        ]
+        summary = {"total_records": 2, "latest_acute_rejection_rates": {}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(Path(tmpdir) / "kidney_outcomes_flat.json", "w") as f:
+                json.dump(data, f)
+            with open(Path(tmpdir) / "kidney_summary.json", "w") as f:
+                json.dump(summary, f)
+
+            srtr = SRTROutcomesData(organ="kidney", data_dir=tmpdir)
+            rate = srtr.get_graft_survival_rate(12, "35-49")
+
+            assert rate == 96.0
+
+    def test_returns_average_without_age_filter(self):
+        data = [
+            {
+                "metric": "graft_survival",
+                "years_post_transplant": 0.5,
+                "survival_rate": 98.0,
+            },
+            {
+                "metric": "graft_survival",
+                "years_post_transplant": 0.5,
+                "survival_rate": 96.0,
+            },
+        ]
+        summary = {"total_records": 2, "latest_acute_rejection_rates": {}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(Path(tmpdir) / "kidney_outcomes_flat.json", "w") as f:
+                json.dump(data, f)
+            with open(Path(tmpdir) / "kidney_summary.json", "w") as f:
+                json.dump(summary, f)
+
+            srtr = SRTROutcomesData(organ="kidney", data_dir=tmpdir)
+            rate = srtr.get_graft_survival_rate(6)
+
+            assert rate == 97.0
+
+    def test_falls_back_to_summary_1yr_average(self):
+        data = [{"metric": "other_metric", "years_post_transplant": 1.0}]
+        summary = {
+            "total_records": 1,
+            "latest_acute_rejection_rates": {},
+            "average_graft_survival_1yr": {"35-49": 94.5},
+        }
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(Path(tmpdir) / "kidney_outcomes_flat.json", "w") as f:
+                json.dump(data, f)
+            with open(Path(tmpdir) / "kidney_summary.json", "w") as f:
+                json.dump(summary, f)
+
+            srtr = SRTROutcomesData(organ="kidney", data_dir=tmpdir)
+            rate = srtr.get_graft_survival_rate(6, "35-49")
+
+            assert rate == 94.5
+
+    def test_returns_default_when_no_matches_and_no_age_group(self):
+        data = [{"metric": "other_metric", "years_post_transplant": 1.0}]
+        summary = {"total_records": 1, "latest_acute_rejection_rates": {}}
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with open(Path(tmpdir) / "kidney_outcomes_flat.json", "w") as f:
+                json.dump(data, f)
+            with open(Path(tmpdir) / "kidney_summary.json", "w") as f:
+                json.dump(summary, f)
+
+            srtr = SRTROutcomesData(organ="kidney", data_dir=tmpdir)
+            rate = srtr.get_graft_survival_rate(6)
+
+            assert rate == 98.0

--- a/tests/unit/pubsub/test_response_aggregator_wait.py
+++ b/tests/unit/pubsub/test_response_aggregator_wait.py
@@ -1,0 +1,165 @@
+"""Tests for ResponseAggregator.wait_for_responses — the subscriber loop."""
+
+import json
+import threading
+from unittest.mock import MagicMock, patch
+
+from services.pubsub.response_aggregator import ResponseAggregator
+
+
+def _make_response(request_id: str, agent_type: str) -> dict:
+    return {
+        "request_id": request_id,
+        "agent_type": agent_type,
+        "agent_response": {"recommendation": "test"},
+        "processing_time": 0.5,
+    }
+
+
+class TestWaitForResponses:
+    @patch("services.pubsub.response_aggregator.pubsub_v1")
+    def test_receives_all_responses(self, mock_pubsub):
+        mock_subscriber = MagicMock()
+        mock_pubsub.SubscriberClient.return_value = mock_subscriber
+        mock_subscriber.subscription_path.return_value = "path"
+
+        captured_callback = {}
+
+        def fake_subscribe(_path, callback):
+            captured_callback["cb"] = callback
+            future = MagicMock()
+
+            def deliver():
+                for rid, atype in [("r1", "MedicationAdvisor"), ("r2", "SymptomMonitor")]:
+                    msg = MagicMock()
+                    msg.data = json.dumps(_make_response(rid, atype)).encode("utf-8")
+                    callback(msg)
+
+            threading.Timer(0.05, deliver).start()
+            return future
+
+        mock_subscriber.subscribe.side_effect = fake_subscribe
+
+        agg = ResponseAggregator(timeout_seconds=2.0)
+        result = agg.wait_for_responses(
+            request_ids=["r1", "r2"],
+            expected_count=2,
+        )
+
+        assert result["complete"] is True
+        assert result["timeout"] is False
+        assert len(result["responses"]) == 2
+        assert "synthesis" in result
+
+    @patch("services.pubsub.response_aggregator.pubsub_v1")
+    def test_timeout_with_partial_responses(self, mock_pubsub):
+        mock_subscriber = MagicMock()
+        mock_pubsub.SubscriberClient.return_value = mock_subscriber
+        mock_subscriber.subscription_path.return_value = "path"
+
+        def fake_subscribe(_path, callback):
+            msg = MagicMock()
+            msg.data = json.dumps(_make_response("r1", "MedicationAdvisor")).encode("utf-8")
+            threading.Timer(0.05, lambda: callback(msg)).start()
+            return MagicMock()
+
+        mock_subscriber.subscribe.side_effect = fake_subscribe
+
+        agg = ResponseAggregator(timeout_seconds=0.3)
+        result = agg.wait_for_responses(
+            request_ids=["r1", "r2"],
+            expected_count=2,
+        )
+
+        assert result["complete"] is False
+        assert result["timeout"] is True
+        assert len(result["responses"]) == 1
+
+    @patch("services.pubsub.response_aggregator.pubsub_v1")
+    def test_callback_invoked_per_response(self, mock_pubsub):
+        mock_subscriber = MagicMock()
+        mock_pubsub.SubscriberClient.return_value = mock_subscriber
+        mock_subscriber.subscription_path.return_value = "path"
+
+        def fake_subscribe(_path, callback):
+            msg = MagicMock()
+            msg.data = json.dumps(_make_response("r1", "MedicationAdvisor")).encode("utf-8")
+            threading.Timer(0.05, lambda: callback(msg)).start()
+            return MagicMock()
+
+        mock_subscriber.subscribe.side_effect = fake_subscribe
+
+        callback_results = []
+        agg = ResponseAggregator(timeout_seconds=0.3)
+        agg.wait_for_responses(
+            request_ids=["r1"],
+            expected_count=1,
+            callback=lambda r: callback_results.append(r),
+        )
+
+        assert len(callback_results) == 1
+        assert callback_results[0]["request_id"] == "r1"
+
+    @patch("services.pubsub.response_aggregator.pubsub_v1")
+    def test_ignores_untracked_request_ids(self, mock_pubsub):
+        mock_subscriber = MagicMock()
+        mock_pubsub.SubscriberClient.return_value = mock_subscriber
+        mock_subscriber.subscription_path.return_value = "path"
+
+        def fake_subscribe(_path, callback):
+            def deliver():
+                untracked = MagicMock()
+                untracked.data = json.dumps(_make_response("unknown", "X")).encode("utf-8")
+                callback(untracked)
+
+                tracked = MagicMock()
+                tracked.data = json.dumps(_make_response("r1", "Med")).encode("utf-8")
+                callback(tracked)
+
+            threading.Timer(0.05, deliver).start()
+            return MagicMock()
+
+        mock_subscriber.subscribe.side_effect = fake_subscribe
+
+        agg = ResponseAggregator(timeout_seconds=0.5)
+        result = agg.wait_for_responses(request_ids=["r1"], expected_count=1)
+
+        assert len(result["responses"]) == 1
+        assert result["responses"][0]["request_id"] == "r1"
+
+    @patch("services.pubsub.response_aggregator.pubsub_v1")
+    def test_handles_malformed_message(self, mock_pubsub):
+        mock_subscriber = MagicMock()
+        mock_pubsub.SubscriberClient.return_value = mock_subscriber
+        mock_subscriber.subscription_path.return_value = "path"
+
+        def fake_subscribe(_path, callback):
+            def deliver():
+                bad = MagicMock()
+                bad.data = b"not json"
+                callback(bad)
+
+            threading.Timer(0.05, deliver).start()
+            return MagicMock()
+
+        mock_subscriber.subscribe.side_effect = fake_subscribe
+
+        agg = ResponseAggregator(timeout_seconds=0.3)
+        result = agg.wait_for_responses(request_ids=["r1"], expected_count=1)
+
+        assert result["timeout"] is True
+        assert len(result["responses"]) == 0
+
+    @patch("services.pubsub.response_aggregator.pubsub_v1")
+    def test_timeout_no_responses(self, mock_pubsub):
+        mock_subscriber = MagicMock()
+        mock_pubsub.SubscriberClient.return_value = mock_subscriber
+        mock_subscriber.subscription_path.return_value = "path"
+        mock_subscriber.subscribe.return_value = MagicMock()
+
+        agg = ResponseAggregator(timeout_seconds=0.1)
+        result = agg.wait_for_responses(request_ids=["r1"], expected_count=1)
+
+        assert result["complete"] is False
+        assert result["timeout"] is True
+        assert result["synthesis"]["status"] == "error"

--- a/tests/unit/pubsub/test_standalone_callbacks.py
+++ b/tests/unit/pubsub/test_standalone_callbacks.py
@@ -1,0 +1,122 @@
+"""Tests for specialist_subscribers standalone functions and _publish_error_response."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+from services.pubsub.specialist_subscribers import (
+    on_drug_interaction_request,
+    on_medication_request,
+    on_symptom_request,
+)
+
+
+class TestPublishErrorResponse:
+    def test_publish_error_response(self):
+        with (
+            patch("services.pubsub.specialist_subscribers.pubsub_v1") as mock_pubsub,
+            patch("services.pubsub.specialist_subscribers.MedicationAdvisorAgent"),
+            patch("services.pubsub.specialist_subscribers.SymptomMonitorAgent"),
+            patch("services.pubsub.specialist_subscribers.DrugInteractionCheckerAgent"),
+            patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+        ):
+            mock_publisher = MagicMock()
+            mock_pubsub.PublisherClient.return_value = mock_publisher
+            mock_publisher.topic_path.return_value = "path"
+            mock_future = MagicMock()
+            mock_future.result.return_value = "id"
+            mock_publisher.publish.return_value = mock_future
+
+            from services.pubsub.specialist_subscribers import SpecialistSubscribers
+
+            subs = SpecialistSubscribers()
+            subs._publish_error_response(
+                {"request_id": "err-1", "patient_id": "P1"}, "Something broke"
+            )
+
+            call_args = mock_publisher.publish.call_args
+            data = json.loads(call_args[0][1].decode("utf-8"))
+            assert data["agent_type"] == "Error"
+            assert data["status"] == "error"
+            assert data["agent_response"]["error"] == "Something broke"
+
+
+class TestPublishResponseException:
+    def test_publish_response_reraises_on_future_failure(self):
+        with (
+            patch("services.pubsub.specialist_subscribers.pubsub_v1") as mock_pubsub,
+            patch("services.pubsub.specialist_subscribers.MedicationAdvisorAgent"),
+            patch("services.pubsub.specialist_subscribers.SymptomMonitorAgent"),
+            patch("services.pubsub.specialist_subscribers.DrugInteractionCheckerAgent"),
+            patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+        ):
+            mock_publisher = MagicMock()
+            mock_pubsub.PublisherClient.return_value = mock_publisher
+            mock_publisher.topic_path.return_value = "path"
+            mock_future = MagicMock()
+            mock_future.result.side_effect = RuntimeError("Publish failed")
+            mock_publisher.publish.return_value = mock_future
+
+            from services.pubsub.specialist_subscribers import SpecialistSubscribers
+
+            subs = SpecialistSubscribers()
+            import pytest
+
+            with pytest.raises(RuntimeError, match="Publish failed"):
+                subs._publish_response({"request_id": "r1", "agent_type": "Test", "data": "x"})
+
+
+class TestGetSpecialistSubscribersSingleton:
+    def test_creates_singleton_when_none(self):
+        with (
+            patch("services.pubsub.specialist_subscribers.pubsub_v1") as mock_pubsub,
+            patch("services.pubsub.specialist_subscribers.MedicationAdvisorAgent"),
+            patch("services.pubsub.specialist_subscribers.SymptomMonitorAgent"),
+            patch("services.pubsub.specialist_subscribers.DrugInteractionCheckerAgent"),
+            patch.dict("os.environ", {"GEMINI_API_KEY": "test-key"}),
+        ):
+            mock_publisher = MagicMock()
+            mock_pubsub.PublisherClient.return_value = mock_publisher
+            mock_publisher.topic_path.return_value = "path"
+
+            import services.pubsub.specialist_subscribers as mod
+
+            mod._specialist_subscribers = None
+            result = mod.get_specialist_subscribers()
+            assert result is not None
+            assert isinstance(result, mod.SpecialistSubscribers)
+            mod._specialist_subscribers = None
+
+
+class TestStandaloneCallbacks:
+    @patch("services.pubsub.specialist_subscribers._specialist_subscribers")
+    @patch("services.pubsub.specialist_subscribers.get_specialist_subscribers")
+    def test_on_medication_request_delegates(self, mock_get, mock_singleton):
+        mock_subs = MagicMock()
+        mock_get.return_value = mock_subs
+        msg = MagicMock()
+
+        on_medication_request(msg)
+
+        mock_subs.on_medication_request.assert_called_once_with(msg)
+
+    @patch("services.pubsub.specialist_subscribers._specialist_subscribers")
+    @patch("services.pubsub.specialist_subscribers.get_specialist_subscribers")
+    def test_on_symptom_request_delegates(self, mock_get, mock_singleton):
+        mock_subs = MagicMock()
+        mock_get.return_value = mock_subs
+        msg = MagicMock()
+
+        on_symptom_request(msg)
+
+        mock_subs.on_symptom_request.assert_called_once_with(msg)
+
+    @patch("services.pubsub.specialist_subscribers._specialist_subscribers")
+    @patch("services.pubsub.specialist_subscribers.get_specialist_subscribers")
+    def test_on_drug_interaction_request_delegates(self, mock_get, mock_singleton):
+        mock_subs = MagicMock()
+        mock_get.return_value = mock_subs
+        msg = MagicMock()
+
+        on_drug_interaction_request(msg)
+
+        mock_subs.on_drug_interaction_request.assert_called_once_with(msg)


### PR DESCRIPTION
## Summary
- Add 7 new test files covering every remaining uncovered branch across `services/`
- 887/887 statements covered (100%), 221 tests passing
- No source code changes, test-only additions

### Test files added
- `test_base_adk_agent.py` — session creation when None, default `_parse_agent_response`
- `test_coordinator_coverage.py` — classify_request_type, sequential/parallel consult, synthesis
- `test_response_parser_edges.py` — unclosed code blocks, escaped quotes, incomplete JSON
- `test_srtr_exception_paths.py` — SRTR unavailable in medication_advisor and rejection_risk
- `test_srtr_graft_survival.py` — graft survival rate with/without age filter, summary fallback, default
- `test_response_aggregator_wait.py` — wait_for_responses: full receive, timeout, callbacks, malformed msgs
- `test_standalone_callbacks.py` — publish failure reraise, singleton creation, standalone callback delegation

## Test plan
- [x] `pytest tests/unit/ --cov=services --cov-report=term-missing` shows 100% (0 missing lines)
- [x] All 221 tests pass
- [x] Ruff, mypy, bandit, gitleaks all pass via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)