### PR TITLE
refactor: clear all 7 cognitive-complexity violations (24/23/19/17/16 -> under 15)

### DIFF
--- a/scripts/parse_srtr_data.py
+++ b/scripts/parse_srtr_data.py
@@ -265,37 +265,52 @@ class SRTRDataParser:
             "average_graft_survival_1yr": {},
         }
 
-        # Count records per dataset
-        for dataset_name, records in data.items():
-            if isinstance(records, list):
-                summary["total_records"] += len(records)
-                summary["datasets"][dataset_name] = len(records)
+        total, per_dataset = self._count_records(data)
+        summary["total_records"] = total
+        summary["datasets"] = per_dataset
 
-        # Extract latest acute rejection rates (2022)
         if "acute_rejection_by_age" in data:
-            latest_year = 2022
-            for record in data["acute_rejection_by_age"]:
-                if record["year"] == latest_year:
-                    age_group = record["age_group"]
-                    summary["latest_acute_rejection_rates"][age_group] = record["rejection_rate"]
+            summary["latest_acute_rejection_rates"] = self._latest_rejection_rates(
+                data["acute_rejection_by_age"]
+            )
 
-        # Calculate average 1-year graft survival by age
         if "graft_survival_by_age" in data:
-            one_year_data = [
-                r for r in data["graft_survival_by_age"] if 0.9 <= r["years_post_transplant"] <= 1.1
-            ]
-            for record in one_year_data:
-                age_group = record["age_group"]
-                if age_group not in summary["average_graft_survival_1yr"]:
-                    summary["average_graft_survival_1yr"][age_group] = []
-                summary["average_graft_survival_1yr"][age_group].append(record["survival_rate"])
-
-            # Average the values
-            for age_group in summary["average_graft_survival_1yr"]:
-                values = summary["average_graft_survival_1yr"][age_group]
-                summary["average_graft_survival_1yr"][age_group] = sum(values) / len(values)
+            summary["average_graft_survival_1yr"] = self._average_1yr_graft_survival(
+                data["graft_survival_by_age"]
+            )
 
         return summary
+
+    @staticmethod
+    def _count_records(data: dict[str, Any]) -> tuple[int, dict[str, int]]:
+        """Total record count and per-dataset counts, skipping non-list values."""
+        per_dataset = {
+            name: len(records) for name, records in data.items() if isinstance(records, list)
+        }
+        return sum(per_dataset.values()), per_dataset
+
+    @staticmethod
+    def _latest_rejection_rates(
+        records: list[dict[str, Any]], latest_year: int = 2022
+    ) -> dict[str, Any]:
+        """Rejection rate per age group for the latest year.
+
+        Later records win on duplicate age groups, matching the original loop.
+        """
+        return {
+            record["age_group"]: record["rejection_rate"]
+            for record in records
+            if record["year"] == latest_year
+        }
+
+    @staticmethod
+    def _average_1yr_graft_survival(records: list[dict[str, Any]]) -> dict[str, float]:
+        """Mean survival rate per age group for records near 1 year post-transplant."""
+        buckets: dict[str, list[float]] = {}
+        for record in records:
+            if 0.9 <= record["years_post_transplant"] <= 1.1:
+                buckets.setdefault(record["age_group"], []).append(record["survival_rate"])
+        return {age_group: sum(values) / len(values) for age_group, values in buckets.items()}
 
 
 def main():

--- a/scripts/parse_srtr_data_v2.py
+++ b/scripts/parse_srtr_data_v2.py
@@ -127,52 +127,86 @@ class SRTRDataParserV2:
 
         for sheet_name in matching_sheets:
             try:
-                df = pd.read_excel(file_path, sheet_name=sheet_name)
-
-                # Clean up - skip unnamed columns
-                df = df.iloc[:, 8:]  # Skip first 8 columns (formatting)
-                df = df.dropna(how="all")
-
-                # Determine what the first column represents
-                first_col_name = df.columns[0]
-
-                for _, row in df.iterrows():
-                    time_or_year = row.iloc[0]
-                    if pd.isna(time_or_year):
-                        continue
-
-                    # Iterate through demographic/age columns
-                    for col in df.columns[1:]:
-                        value = row[col]
-                        if pd.isna(value):
-                            continue
-
-                        record = {
-                            "metric": metric_name,
-                            "organ": organ,
-                            "source": "SRTR 2023",
-                            "sheet": sheet_name,
-                        }
-
-                        # Add time/year field
-                        if "year" in first_col_name.lower() or (
-                            "year" in sheet_name.lower() or "inc-AR" in sheet_name
-                        ):
-                            record["year"] = int(time_or_year)
-                        else:
-                            record["time_value"] = float(time_or_year)
-
-                        # Add demographic field
-                        record["demographic"] = col
-                        record["value"] = float(value)
-
-                        all_records.append(record)
-
+                all_records.extend(self._parse_sheet(file_path, sheet_name, metric_name, organ))
             except Exception as e:
                 print(f"    ⚠️  Error parsing {sheet_name}: {e}")
                 continue
 
         return all_records
+
+    def _parse_sheet(
+        self,
+        file_path: Path,
+        sheet_name: str,
+        metric_name: str,
+        organ: str,
+    ) -> list[dict[str, Any]]:
+        """Parse a single matched sheet into records."""
+        df = pd.read_excel(file_path, sheet_name=sheet_name)
+
+        # Clean up - skip unnamed columns
+        df = df.iloc[:, 8:]  # Skip first 8 columns (formatting)
+        df = df.dropna(how="all")
+
+        # Determine what the first column represents. Loop-invariant, so it is
+        # resolved once here rather than re-evaluated per cell as it was.
+        first_col_name = df.columns[0]
+        is_year_column = "year" in first_col_name.lower() or (
+            "year" in sheet_name.lower() or "inc-AR" in sheet_name
+        )
+
+        records: list[dict[str, Any]] = []
+        for _, row in df.iterrows():
+            time_or_year = row.iloc[0]
+            if pd.isna(time_or_year):
+                continue
+            records.extend(
+                self._records_from_row(
+                    row=row,
+                    columns=df.columns[1:],
+                    time_or_year=time_or_year,
+                    is_year_column=is_year_column,
+                    metric_name=metric_name,
+                    organ=organ,
+                    sheet_name=sheet_name,
+                )
+            )
+        return records
+
+    @staticmethod
+    def _records_from_row(
+        *,
+        row: Any,
+        columns: Any,
+        time_or_year: Any,
+        is_year_column: bool,
+        metric_name: str,
+        organ: str,
+        sheet_name: str,
+    ) -> list[dict[str, Any]]:
+        """One record per non-null demographic/age column in a row."""
+        records: list[dict[str, Any]] = []
+        for col in columns:
+            value = row[col]
+            if pd.isna(value):
+                continue
+
+            record: dict[str, Any] = {
+                "metric": metric_name,
+                "organ": organ,
+                "source": "SRTR 2023",
+                "sheet": sheet_name,
+            }
+
+            if is_year_column:
+                record["year"] = int(time_or_year)
+            else:
+                record["time_value"] = float(time_or_year)
+
+            record["demographic"] = col
+            record["value"] = float(value)
+            records.append(record)
+        return records
 
     def save_json(self, data: dict[str, Any], organ: str) -> None:
         """Save parsed data to JSON."""

--- a/services/agents/coordinator_agent.py
+++ b/services/agents/coordinator_agent.py
@@ -21,6 +21,28 @@ from services.config.adk_config import (
     GEMINI_API_KEY,
 )
 
+# Keyword routing table. Order matters: it determines the order agents appear
+# in the routing decision, matching the sequential if-blocks this replaced.
+ROUTING_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("MedicationAdvisor", ("missed", "late", "dose", "timing", "forgot")),
+    (
+        "SymptomMonitor",
+        ("symptom", "feeling", "fever", "pain", "rejection", "urine", "weight"),
+    ),
+    (
+        "DrugInteractionChecker",
+        (
+            "interaction",
+            "taking",
+            "new medication",
+            "food",
+            "grapefruit",
+            "ibuprofen",
+            "supplement",
+        ),
+    ),
+)
+
 
 class TransplantCoordinatorAgent:
     """
@@ -182,47 +204,29 @@ Respond with JSON: {{
 
         # Parse routing decision (simplified for now)
         # In real implementation, parse JSON from response
-        request_lower = request.lower()
-
-        agents_needed = []
-        if any(word in request_lower for word in ["missed", "late", "dose", "timing", "forgot"]):
-            agents_needed.append("MedicationAdvisor")
-        if any(
-            word in request_lower
-            for word in [
-                "symptom",
-                "feeling",
-                "fever",
-                "pain",
-                "rejection",
-                "urine",
-                "weight",
-            ]
-        ):
-            agents_needed.append("SymptomMonitor")
-        if any(
-            word in request_lower
-            for word in [
-                "interaction",
-                "taking",
-                "new medication",
-                "food",
-                "grapefruit",
-                "ibuprofen",
-                "supplement",
-            ]
-        ):
-            agents_needed.append("DrugInteractionChecker")
-
-        # Default to MedicationAdvisor if unclear
-        if not agents_needed:
-            agents_needed.append("MedicationAdvisor")
+        agents_needed = self._agents_for_request(request)
 
         return {
             "agents_needed": agents_needed,
             "reasoning": str(response),
             "request_type": self._classify_request_type(agents_needed),
         }
+
+    @staticmethod
+    def _agents_for_request(request: str) -> list[str]:
+        """Keyword-route a request to the specialist agents that should see it.
+
+        Falls back to MedicationAdvisor when nothing matches. Order of the
+        returned list follows ROUTING_KEYWORDS, which is the order the original
+        sequential if-blocks appended in.
+        """
+        request_lower = request.lower()
+        agents = [
+            agent
+            for agent, keywords in ROUTING_KEYWORDS
+            if any(word in request_lower for word in keywords)
+        ]
+        return agents or ["MedicationAdvisor"]
 
     def _classify_request_type(self, agents_needed: list[str]) -> str:
         """Classify request type based on agents needed."""

--- a/services/agents/response_parser.py
+++ b/services/agents/response_parser.py
@@ -6,6 +6,7 @@ standardized parsing logic to extract structured data from those responses.
 """
 
 import json
+from collections.abc import Iterator
 from typing import Any
 
 
@@ -39,17 +40,18 @@ def _extract_code_block(text: str, marker: str) -> str | None:
     return text[content_start:content_end]
 
 
-def _find_json_object(text: str) -> str | None:
-    """Find first complete JSON object by counting braces."""
-    brace_index = text.find("{")
-    if brace_index == -1:
-        return None
+def _scan_structural_chars(text: str, start: int) -> Iterator[tuple[int, str]]:
+    """Yield (index, char) for characters outside string literals.
 
-    depth = 0
+    Handles the two things that make brace counting non-trivial: backslash
+    escapes, and quotes that toggle in and out of a string literal. Escape and
+    quote characters are consumed here and never yielded, so the caller only
+    ever sees structural characters.
+    """
     in_string = False
     escape_next = False
 
-    for i in range(brace_index, len(text)):
+    for i in range(start, len(text)):
         char = text[i]
 
         if escape_next:
@@ -65,12 +67,23 @@ def _find_json_object(text: str) -> str | None:
             continue
 
         if not in_string:
-            if char == "{":
-                depth += 1
-            elif char == "}":
-                depth -= 1
-                if depth == 0:
-                    return text[brace_index : i + 1]
+            yield i, char
+
+
+def _find_json_object(text: str) -> str | None:
+    """Find first complete JSON object by counting braces."""
+    brace_index = text.find("{")
+    if brace_index == -1:
+        return None
+
+    depth = 0
+    for i, char in _scan_structural_chars(text, brace_index):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace_index : i + 1]
 
     return None
 

--- a/services/missed-dose/main.py
+++ b/services/missed-dose/main.py
@@ -145,6 +145,12 @@ def calculate_adherence(patient_id):
     return 0.8, 0
 
 
+# Sentinel for "this symptom is absent". Distinct from None, because a raw
+# value of None IS carried through for fatigue/urine_output in the original
+# logic — collapsing the two would silently drop those keys.
+_OMIT = object()
+
+
 def normalize_rejection_symptoms(raw_symptoms: dict) -> dict:
     """
     Normalize symptom data to match RejectionRiskAgent expected format.
@@ -161,50 +167,14 @@ def normalize_rejection_symptoms(raw_symptoms: dict) -> dict:
     """
     normalized = {}
 
-    # Handle fever (can be boolean + temperature, or just temperature)
-    if "fever_temperature" in raw_symptoms:
-        normalized["fever"] = raw_symptoms["fever_temperature"]
-    elif "fever" in raw_symptoms:
-        fever_val = raw_symptoms["fever"]
-        # If fever is boolean True and no temperature, assume mild fever
-        if fever_val is True:
-            normalized["fever"] = 99.5
-        elif isinstance(fever_val, int | float):
-            normalized["fever"] = fever_val
-        # If fever is False or missing, don't include it
-
-    # Handle weight gain
-    if "weight_gain" in raw_symptoms:
-        normalized["weight_gain"] = raw_symptoms["weight_gain"]
-    elif "weight_gain_lbs" in raw_symptoms:
-        normalized["weight_gain"] = raw_symptoms["weight_gain_lbs"]
-
-    # Handle fatigue (convert boolean to description)
-    if "fatigue" in raw_symptoms:
-        fatigue_val = raw_symptoms["fatigue"]
-        if fatigue_val is True:
-            normalized["fatigue"] = "moderate"
-        elif fatigue_val is False:
-            normalized["fatigue"] = "none"
-        else:
-            normalized["fatigue"] = fatigue_val
-    elif "fatigue_level" in raw_symptoms:
-        normalized["fatigue"] = raw_symptoms["fatigue_level"]
-
-    # Handle urine output (convert boolean to description)
-    if "decreased_urine_output" in raw_symptoms:
-        if raw_symptoms["decreased_urine_output"] is True:
-            normalized["urine_output"] = "decreased"
-        elif raw_symptoms["decreased_urine_output"] is False:
-            normalized["urine_output"] = "normal"
-    elif "urine_output" in raw_symptoms:
-        urine_val = raw_symptoms["urine_output"]
-        if urine_val is True:
-            normalized["urine_output"] = "decreased"
-        elif urine_val is False:
-            normalized["urine_output"] = "normal"
-        else:
-            normalized["urine_output"] = urine_val
+    for key, value in (
+        ("fever", _normalize_fever(raw_symptoms)),
+        ("weight_gain", _normalize_weight_gain(raw_symptoms)),
+        ("fatigue", _normalize_fatigue(raw_symptoms)),
+        ("urine_output", _normalize_urine_output(raw_symptoms)),
+    ):
+        if value is not _OMIT:
+            normalized[key] = value
 
     # Pass through any other symptom fields directly
     other_fields = ["tenderness", "swelling", "pain", "nausea"]
@@ -213,6 +183,71 @@ def normalize_rejection_symptoms(raw_symptoms: dict) -> dict:
             normalized[field] = raw_symptoms[field]
 
     return normalized
+
+
+def _normalize_fever(raw_symptoms: dict):
+    """Fever as a temperature. Boolean True means an unmeasured mild fever."""
+    if "fever_temperature" in raw_symptoms:
+        return raw_symptoms["fever_temperature"]
+    if "fever" not in raw_symptoms:
+        return _OMIT
+
+    fever_val = raw_symptoms["fever"]
+    # `is True` must precede the isinstance check: bool subclasses int, so True
+    # would otherwise be passed through as the temperature 1.
+    if fever_val is True:
+        return 99.5
+    if isinstance(fever_val, int | float):
+        return fever_val
+    # False, None or anything non-numeric: omit rather than report a fever.
+    return _OMIT
+
+
+def _normalize_weight_gain(raw_symptoms: dict):
+    """Weight gain in lbs, under either accepted key."""
+    if "weight_gain" in raw_symptoms:
+        return raw_symptoms["weight_gain"]
+    if "weight_gain_lbs" in raw_symptoms:
+        return raw_symptoms["weight_gain_lbs"]
+    return _OMIT
+
+
+def _normalize_fatigue(raw_symptoms: dict):
+    """Fatigue as a description; booleans map to moderate/none."""
+    if "fatigue" in raw_symptoms:
+        fatigue_val = raw_symptoms["fatigue"]
+        if fatigue_val is True:
+            return "moderate"
+        if fatigue_val is False:
+            return "none"
+        return fatigue_val
+    if "fatigue_level" in raw_symptoms:
+        return raw_symptoms["fatigue_level"]
+    return _OMIT
+
+
+def _normalize_urine_output(raw_symptoms: dict):
+    """Urine output as a description; booleans map to decreased/normal.
+
+    Note the asymmetry, preserved from the original: under
+    `decreased_urine_output` a non-boolean is dropped, whereas under
+    `urine_output` it is passed through unchanged.
+    """
+    if "decreased_urine_output" in raw_symptoms:
+        decreased = raw_symptoms["decreased_urine_output"]
+        if decreased is True:
+            return "decreased"
+        if decreased is False:
+            return "normal"
+        return _OMIT
+    if "urine_output" in raw_symptoms:
+        urine_val = raw_symptoms["urine_output"]
+        if urine_val is True:
+            return "decreased"
+        if urine_val is False:
+            return "normal"
+        return urine_val
+    return _OMIT
 
 
 def record_interaction(patient_id, interaction_type, data):

--- a/services/missed-dose/services/agents/coordinator_agent.py
+++ b/services/missed-dose/services/agents/coordinator_agent.py
@@ -21,6 +21,28 @@ from services.config.adk_config import (
     GEMINI_API_KEY,
 )
 
+# Keyword routing table. Order matters: it determines the order agents appear
+# in the routing decision, matching the sequential if-blocks this replaced.
+ROUTING_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("MedicationAdvisor", ("missed", "late", "dose", "timing", "forgot")),
+    (
+        "SymptomMonitor",
+        ("symptom", "feeling", "fever", "pain", "rejection", "urine", "weight"),
+    ),
+    (
+        "DrugInteractionChecker",
+        (
+            "interaction",
+            "taking",
+            "new medication",
+            "food",
+            "grapefruit",
+            "ibuprofen",
+            "supplement",
+        ),
+    ),
+)
+
 
 class TransplantCoordinatorAgent:
     """
@@ -182,47 +204,29 @@ Respond with JSON: {{
 
         # Parse routing decision (simplified for now)
         # In real implementation, parse JSON from response
-        request_lower = request.lower()
-
-        agents_needed = []
-        if any(word in request_lower for word in ["missed", "late", "dose", "timing", "forgot"]):
-            agents_needed.append("MedicationAdvisor")
-        if any(
-            word in request_lower
-            for word in [
-                "symptom",
-                "feeling",
-                "fever",
-                "pain",
-                "rejection",
-                "urine",
-                "weight",
-            ]
-        ):
-            agents_needed.append("SymptomMonitor")
-        if any(
-            word in request_lower
-            for word in [
-                "interaction",
-                "taking",
-                "new medication",
-                "food",
-                "grapefruit",
-                "ibuprofen",
-                "supplement",
-            ]
-        ):
-            agents_needed.append("DrugInteractionChecker")
-
-        # Default to MedicationAdvisor if unclear
-        if not agents_needed:
-            agents_needed.append("MedicationAdvisor")
+        agents_needed = self._agents_for_request(request)
 
         return {
             "agents_needed": agents_needed,
             "reasoning": str(response),
             "request_type": self._classify_request_type(agents_needed),
         }
+
+    @staticmethod
+    def _agents_for_request(request: str) -> list[str]:
+        """Keyword-route a request to the specialist agents that should see it.
+
+        Falls back to MedicationAdvisor when nothing matches. Order of the
+        returned list follows ROUTING_KEYWORDS, which is the order the original
+        sequential if-blocks appended in.
+        """
+        request_lower = request.lower()
+        agents = [
+            agent
+            for agent, keywords in ROUTING_KEYWORDS
+            if any(word in request_lower for word in keywords)
+        ]
+        return agents or ["MedicationAdvisor"]
 
     def _classify_request_type(self, agents_needed: list[str]) -> str:
         """Classify request type based on agents needed."""

--- a/services/missed-dose/services/agents/response_parser.py
+++ b/services/missed-dose/services/agents/response_parser.py
@@ -6,6 +6,7 @@ standardized parsing logic to extract structured data from those responses.
 """
 
 import json
+from collections.abc import Iterator
 from typing import Any
 
 
@@ -39,17 +40,18 @@ def _extract_code_block(text: str, marker: str) -> str | None:
     return text[content_start:content_end]
 
 
-def _find_json_object(text: str) -> str | None:
-    """Find first complete JSON object by counting braces."""
-    brace_index = text.find("{")
-    if brace_index == -1:
-        return None
+def _scan_structural_chars(text: str, start: int) -> Iterator[tuple[int, str]]:
+    """Yield (index, char) for characters outside string literals.
 
-    depth = 0
+    Handles the two things that make brace counting non-trivial: backslash
+    escapes, and quotes that toggle in and out of a string literal. Escape and
+    quote characters are consumed here and never yielded, so the caller only
+    ever sees structural characters.
+    """
     in_string = False
     escape_next = False
 
-    for i in range(brace_index, len(text)):
+    for i in range(start, len(text)):
         char = text[i]
 
         if escape_next:
@@ -65,12 +67,23 @@ def _find_json_object(text: str) -> str | None:
             continue
 
         if not in_string:
-            if char == "{":
-                depth += 1
-            elif char == "}":
-                depth -= 1
-                if depth == 0:
-                    return text[brace_index : i + 1]
+            yield i, char
+
+
+def _find_json_object(text: str) -> str | None:
+    """Find first complete JSON object by counting braces."""
+    brace_index = text.find("{")
+    if brace_index == -1:
+        return None
+
+    depth = 0
+    for i, char in _scan_structural_chars(text, brace_index):
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace_index : i + 1]
 
     return None
 


### PR DESCRIPTION
Clears **every** cognitive-complexity violation in this repo — 7 violations across 5 unique functions. `coordinator_agent.py` and `response_parser.py` are byte-identical copies under `services/agents/` and `services/missed-dose/services/agents/`, so each fix lands twice.

| file | function | before |
|---|---|---|
| `scripts/parse_srtr_data_v2.py` | `_parse_pattern` | **24** |
| `services/missed-dose/main.py` | `normalize_rejection_symptoms` | **23** |
| `services/agents/response_parser.py` | `_find_json_object` | 19 (×2) |
| `scripts/parse_srtr_data.py` | `generate_summary_stats` | 17 |
| `services/agents/coordinator_agent.py` | `_analyze_routing` | 16 (×2) |

No behaviour changes.

## Two changes carried real risk and were differential-tested

Existing tests don't cover these paths well, so rather than trusting the refactor I ran each new implementation against the original on generated inputs.

**`_find_json_object`** — a brace-counting scanner where string/escape lexing and depth counting were fused into one loop. Split into a generator yielding only *structural* characters, so the caller does nothing but count braces.

> 21 adversarial inputs — escaped quotes, escaped backslashes, braces inside string literals, nested objects, unbalanced input, empty string. **0 mismatches.**

**`normalize_rejection_symptoms`** — needed a sentinel, not `None`. The original sets `normalized["fatigue"] = None` when the raw value is `None`, so collapsing "absent" and "None" into one would have silently dropped those keys. `_OMIT` preserves the distinction.

> 216 generated cases across every key × value combination, plus all key pairs. **0 mismatches.**

## Other subtleties preserved

- **`fever` checks `is True` before `isinstance(int|float)`** — `bool` subclasses `int`, so `True` would otherwise be passed through as the temperature `1`.
- **`decreased_urine_output` drops a non-boolean while `urine_output` passes it through.** An asymmetry in the original, kept and now documented rather than quietly normalised.
- `_latest_rejection_rates` keeps last-wins on duplicate age groups.
- `ROUTING_KEYWORDS` order matches the sequential `if`-blocks it replaced, so `agents_needed` ordering is unchanged.
- `is_year_column` is loop-invariant and is now resolved once per sheet instead of per cell — same value, less work.

## Tests

```
187 passed, 19 failed, 41 skipped
```

**The same 19 failures occur on `main`.** Verified by diffing the failure sets before and after the change — the two lists are identical, zero new. They are pre-existing environment gaps (`google.adk`, `google.cloud.firestore` not installed in the runner I used), not regressions from this PR.

## Context

Part of a workspace sweep: `~/Code` had 24 cognitive-complexity violations across 7 Python repos. The canonical pre-commit template in devops now carries a blocking `CCR001@15` gate (adamkwhite/devops#27).

The duplicated `services/agents/` tree is worth a separate look — two byte-identical copies of the same modules will drift eventually, and this PR had to patch both by hand.
